### PR TITLE
Docs/#4/supply args to install instruction

### DIFF
--- a/docs/03.admin-guide/admin-guide.ja.md
+++ b/docs/03.admin-guide/admin-guide.ja.md
@@ -224,7 +224,7 @@ nfs:
 #### 3. インストールする
 
 ```
-./installer.sh --kubeconfig path/to/kubeconfig -n NAMESPACE -s ./Knitfab-install-settings
+./installer.sh --install --kubeconfig path/to/kubeconfig -n NAMESPACE -s ./knitfab-install-settings
 ```
 
 このコマンドを実行することで、インストールスクリプトが順次 Knitfab のコンポーネントを kubernetes クラスタにインストールする。しばらく時間がかかるだろう。

--- a/docs/03.admin-guide/admin-guide.ja.md
+++ b/docs/03.admin-guide/admin-guide.ja.md
@@ -123,10 +123,10 @@ chmod +x ./installer.sh
 #### 手順2: インストール設定ファイルを生成し、パラメータを調整する
 
 ```
-./installer.sh --prepare
+./installer.sh --prepare --kubeconfig ${YOUR_KUBECONFIG}
 ```
 
-を実行すると、 `./knitfab_install_settings` ディレクトリに Knitfab のインストール設定が生成される。
+を実行すると、 `./knitfab-install-settings` ディレクトリに Knitfab のインストール設定が生成される。 `${YOUR_KUBECONFIG}` の部分は、インストール先となる kubernetes 用の kubeconfig ファイルへのパスに置き換えてほしい。
 
 > [!Note]
 >


### PR DESCRIPTION
Fixes admin-guide.

- fix wrong filepath
- supply missing parameter for `./installer.sh`
  - `--kubeconfig` for `./installer.sh --prepare`
  - `--install` for `./installer.sh --install`