### PR TITLE
fix instruction about installing `knit`

### DIFF
--- a/docs/01.getting-started/getting-started.en.md
+++ b/docs/01.getting-started/getting-started.en.md
@@ -171,19 +171,23 @@ CLI Tool: knit
 
 Operations on Knitfab are performed through the CLI command `knit`.
 Before proceeding with the following tutorials, you need to obtain the `knit` command.
-Obtain it using one of the following two methods.
-
-### (1)Obtaining as a binary
 
 The tool can be obtained from https://github.com/opst/knitfab/releases.
 Please download the binary that matches your environment.
 
-### (2)Building it yourself
-
-Install go 1.22 or higher and execute the following command.
+For example:
 
 ```
-go install https://github.com/opst/knitfab/cmd/knit@latest
+mkdir -p ~/.local/bin
+
+VERSION=v1.0.0  # or release which you desired
+OS=linux        # or windows, darwin
+ARCH=arm64      # or amd64
+
+wget -O ~/.local/bin/knit https://github.com/opst/knitfab/releases/download/${VERSION}/knit-${OS}-${ARCH}
+chmod -x ~/.local/bin/knit
+
+# and prepend ~/.local/bin to ${PATH}
 ```
 
 Tutorial 1: Training Models with Knitfab

--- a/docs/01.getting-started/getting-started.ja.md
+++ b/docs/01.getting-started/getting-started.ja.md
@@ -190,19 +190,23 @@ CLI ツール: knit
 
 Knitfab に対する操作は CLI コマンド `knit` を介して行う。
 以降のチュートリアルに先立ち、 `knit` コマンドを入手する必要がある。
-以下の２つのうち、いずれかの方法で入手すること。
-
-### (1)バイナリとして入手する
 
 ツールは https://github.com/opst/knitfab/releases から入手できる。
 使用する環境にあったバイナリをダウンロードしてほしい。
 
-### (2)自分でビルドする
-
-go 1.22 以上をインストールし、次のコマンドを実行する。
+たとえば、
 
 ```
-go install https://github.com/opst/knitfab/cmd/knit@latest
+mkdir -p ~/.local/bin
+
+VERSION=v1.0.0  # or release which you desired
+OS=linux        # or windows, darwin
+ARCH=arm64      # or amd64
+
+wget -O ~/.local/bin/knit https://github.com/opst/knitfab/releases/download/${VERSION}/knit-${OS}-${ARCH}
+chmod -x ~/.local/bin/knit
+
+# and prepend ~/.local/bin to ${PATH}
 ```
 
 チュートリアル1: Knitfab でモデルを訓練する


### PR DESCRIPTION
Instraction about installing `knit` is wrong. It cannot be installed with `go install`.

This PR removes wrong instractions and supply examples to binary install.

# Related Issue

- closes #10 