### PR TITLE
Bugfix/#58/knit data pull fails randomly

### DIFF
--- a/cmd/dataagt/server/handlers.go
+++ b/cmd/dataagt/server/handlers.go
@@ -33,7 +33,7 @@ func Reader(root string) echo.HandlerFunc {
 		prog := archive.GoTar(ctx, root, gzw)
 		<-prog.Done()
 		if err := prog.Error(); err != nil {
-			return apierr.InternalServerError(err)
+			return err
 		}
 		gzw.Close()
 		resp.Header().Add("x-checksum-md5", hex.EncodeToString(chw.Sum()))

--- a/cmd/knitd_backend/handlers/data.go
+++ b/cmd/knitd_backend/handlers/data.go
@@ -160,8 +160,6 @@ func GetDataHandler(
 			return apierr.InternalServerError(err)
 		}
 
-		echoutil.CopyResponse(&c, bresp) // proxy dataagt response.  -- fixme: check & reword error message.
-
-		return nil
+		return echoutil.CopyResponse(&c, bresp)
 	}
 }


### PR DESCRIPTION
# About This PR

This PR fixes #58 .

`knit data pull` runs stable.

## Root Cause

The flaw is caused by `Flush()` ing responding buffer twice simultaneously.
Response buffer perform `Flush()` when it is written enough.
And, `CopyResponse` (in `pkg/echoutil/proxy.go`) does force`Flush()` periodically.

When 2 `Flush()`-es collides, same buffer is written twice, and that brakes [`Transfer-Encoding: chunked` message structure](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding).
When Go's standard `http` package detects such broken message on writing, it returns `error`.

`CopyResponse` is used in knitd_backend and knitd. So, knitd_backend or knitd caused error by chance depending on 2 `Flush()`-es, and stop proxing responses.

## Fix

`CopyResponse` copies a response body with `io.Copy`. As long as using that, there are no chance to call `Flush()` except for in pararell way.

So, I rewrite that with a plain `Read` and `Write` in  a loop, and call `Flush` sequentially.