### PR TITLE
Feature/#22/run find time based query

### DIFF
--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -204,7 +204,7 @@ type KnitClient interface {
 	// - error
 	GetRunLog(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
 
-	// FindRun find run with given planId, knitId and status.
+	// FindRun find run with given planId, knitId, status, since and duration.
 
 	// Args
 	//
@@ -218,13 +218,18 @@ type KnitClient interface {
 	//
 	// - []string: status which run to be found is
 	//
+	// - string: since which updated time of run to be found is after
+	//
+	// - string: duration which updated time of run to be found is within
+	//
 	// Returns
 	//
 	// - []apirun.Detail: metadata of found run
 	//
 	// - error
 	FindRun(
-		ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string,
+		ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string,
+		status []string, since string, duration string,
 	) ([]apirun.Detail, error)
 
 	// Abort abort run with given runId.

--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	kprof "github.com/opst/knitfab/cmd/knit/config/profiles"
 	apidata "github.com/opst/knitfab/pkg/api/types/data"
@@ -218,9 +219,9 @@ type KnitClient interface {
 	//
 	// - []string: status which run to be found is
 	//
-	// - string: since which updated time of run to be found is after
+	// - time.Time: time which updated time of run to be found is after
 	//
-	// - string: duration which updated time of run to be found is within
+	// - time.duration: duration which updated time of run to be found is within
 	//
 	// Returns
 	//
@@ -229,7 +230,7 @@ type KnitClient interface {
 	// - error
 	FindRun(
 		ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string,
-		status []string, since string, duration string,
+		status []string, since time.Time, duration time.Duration,
 	) ([]apirun.Detail, error)
 
 	// Abort abort run with given runId.

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/opst/knitfab/cmd/knit/rest"
 	apidata "github.com/opst/knitfab/pkg/api/types/data"
@@ -35,8 +36,8 @@ type FindRunArgs struct {
 	KnitIdIn  []string
 	KnitIdOut []string
 	status    []string
-	since     string
-	duration  string
+	since     time.Time
+	duration  time.Duration
 }
 
 func New(t *testing.T) *mockKnitClient {
@@ -107,7 +108,7 @@ type mockKnitClient struct {
 		RegisterPlan       func(ctx context.Context, spec apiplans.PlanSpec) (apiplans.Detail, error)
 		GetRun             func(ctx context.Context, runId string) (apirun.Detail, error)
 		GetRunLog          func(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
-		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string, since, duration string) ([]apirun.Detail, error)
+		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string, since time.Time, duration time.Duration) ([]apirun.Detail, error)
 		Abort              func(ctx context.Context, runId string) (apirun.Detail, error)
 		Tearoff            func(ctx context.Context, runId string) (apirun.Detail, error)
 		DeleteRun          func(ctx context.Context, runId string) error
@@ -285,8 +286,8 @@ func (m *mockKnitClient) FindRun(
 	knitIdIn []string,
 	knitIdOut []string,
 	status []string,
-	since string,
-	duration string,
+	since time.Time,
+	duration time.Duration,
 ) ([]apirun.Detail, error) {
 	m.t.Helper()
 

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -35,6 +35,8 @@ type FindRunArgs struct {
 	KnitIdIn  []string
 	KnitIdOut []string
 	status    []string
+	since     string
+	duration  string
 }
 
 func New(t *testing.T) *mockKnitClient {
@@ -105,7 +107,7 @@ type mockKnitClient struct {
 		RegisterPlan       func(ctx context.Context, spec apiplans.PlanSpec) (apiplans.Detail, error)
 		GetRun             func(ctx context.Context, runId string) (apirun.Detail, error)
 		GetRunLog          func(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
-		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string) ([]apirun.Detail, error)
+		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string, since, duration string) ([]apirun.Detail, error)
 		Abort              func(ctx context.Context, runId string) (apirun.Detail, error)
 		Tearoff            func(ctx context.Context, runId string) (apirun.Detail, error)
 		DeleteRun          func(ctx context.Context, runId string) error
@@ -278,18 +280,24 @@ func (m *mockKnitClient) GetRunLog(ctx context.Context, runId string, follow boo
 }
 
 func (m *mockKnitClient) FindRun(
-	ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string,
+	ctx context.Context,
+	planId []string,
+	knitIdIn []string,
+	knitIdOut []string,
+	status []string,
+	since string,
+	duration string,
 ) ([]apirun.Detail, error) {
 	m.t.Helper()
 
 	m.Calls.FindRun = append(
 		m.Calls.FindRun,
-		FindRunArgs{planId, knitIdIn, knitIdOut, status},
+		FindRunArgs{planId, knitIdIn, knitIdOut, status, since, duration},
 	)
 	if m.Impl.FindRun == nil {
 		m.t.Fatal("FindRun is not ready to be called")
 	}
-	return m.Impl.FindRun(ctx, planId, knitIdIn, knitIdOut, status)
+	return m.Impl.FindRun(ctx, planId, knitIdIn, knitIdOut, status, since, duration)
 }
 
 func (m *mockKnitClient) Abort(ctx context.Context, runId string) (apirun.Detail, error) {

--- a/cmd/knit/rest/run.go
+++ b/cmd/knit/rest/run.go
@@ -69,6 +69,8 @@ func (c *client) FindRun(
 	knitIdIn []string,
 	knitIdOut []string,
 	status []string,
+	since string,
+	duration string,
 ) ([]apirun.Detail, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apipath("runs"), nil)
@@ -83,6 +85,8 @@ func (c *client) FindRun(
 		"knitIdInput":  knitIdIn,
 		"knitIdOutput": knitIdOut,
 		"status":       status,
+		"since":        {since},
+		"duration":     {duration},
 	}
 	for key, value := range paramMap {
 		if len(value) > 0 {

--- a/cmd/knit/rest/run.go
+++ b/cmd/knit/rest/run.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	apirun "github.com/opst/knitfab/pkg/api/types/runs"
+	"github.com/opst/knitfab/pkg/utils/rfctime"
 )
 
 func (c *client) GetRun(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -69,13 +71,27 @@ func (c *client) FindRun(
 	knitIdIn []string,
 	knitIdOut []string,
 	status []string,
-	since string,
-	duration string,
+	since time.Time,
+	duration time.Duration,
 ) ([]apirun.Detail, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apipath("runs"), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	var sinceStr string
+	if since != (time.Time{}) {
+		sinceStr = since.Format(rfctime.RFC3339DateTimeFormatZ)
+	} else {
+		sinceStr = ""
+	}
+
+	var durationStr string
+	if duration != 0 {
+		durationStr = duration.String()
+	} else {
+		durationStr = ""
 	}
 
 	// set query values
@@ -85,8 +101,8 @@ func (c *client) FindRun(
 		"knitIdInput":  knitIdIn,
 		"knitIdOutput": knitIdOut,
 		"status":       status,
-		"since":        {since},
-		"duration":     {duration},
+		"since":        {sinceStr},
+		"duration":     {durationStr},
 	}
 	for key, value := range paramMap {
 		if len(value) > 0 {

--- a/cmd/knit/rest/run_test.go
+++ b/cmd/knit/rest/run_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	kprof "github.com/opst/knitfab/cmd/knit/config/profiles"
 	krst "github.com/opst/knitfab/cmd/knit/rest"
@@ -320,8 +321,8 @@ func TestFindRun(t *testing.T) {
 			knitIdIn  []string
 			knitIdOut []string
 			status    []string
-			since     string
-			duration  string
+			since     time.Time
+			duration  time.Duration
 		}
 
 		type then struct {
@@ -345,8 +346,8 @@ func TestFindRun(t *testing.T) {
 					knitIdIn:  []string{},
 					knitIdOut: []string{},
 					status:    []string{},
-					since:     "",
-					duration:  "",
+					since:     time.Time{},
+					duration:  time.Duration(0),
 				},
 				then: then{
 					planIdInQuery:    []string{},
@@ -363,16 +364,19 @@ func TestFindRun(t *testing.T) {
 					knitIdIn:  []string{"in-a", "in-b"},
 					knitIdOut: []string{"out-a", "out-b"},
 					status:    []string{"wating", "running"},
-					since:     "2024-04-02T12:00:00+00:00",
-					duration:  "2 hours",
+					since: time.Date(
+						2024, 4, 22, 12, 34, 56, 987654321,
+						time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+					),
+					duration: time.Duration(2 * time.Hour),
 				},
 				then: then{
 					planIdInQuery:    []string{"test-a,test-b"},
 					knitIdInInQuery:  []string{"in-a,in-b"},
 					knitIdOutInQuery: []string{"out-a,out-b"},
 					statusInQuery:    []string{"wating,running"},
-					sinceQuery:       "2024-04-02T12:00:00+00:00",
-					durationQuery:    "2 hours",
+					sinceQuery:       "2024-04-22T12:34:56.987654321+07:00",
+					durationQuery:    "2h0m0s",
 				},
 			},
 		} {
@@ -456,8 +460,11 @@ func TestFindRun(t *testing.T) {
 			inputKnitId := []string{"test-inputKnitId"}
 			outputKnitId := []string{"test-outputKnitId"}
 			status := []string{"test-status"}
-			since := "2024-04-02T12:00:00+00:00"
-			duration := "2 hours"
+			since := time.Date(
+				2024, 4, 22, 12, 34, 56, 000000000,
+				time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+			)
+			duration := time.Duration(2 * time.Hour)
 
 			//test start
 			actualResponse := try.To(
@@ -515,8 +522,11 @@ func TestFindRun(t *testing.T) {
 				inputKnitId := []string{"test-inputKnitId"}
 				outputKnitId := []string{"test-outputKnitId"}
 				status := []string{"test-status"}
-				since := "2024-04-02T12:00:00+00:00"
-				duration := "2 hours"
+				since := time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				)
+				duration := time.Duration(2 * time.Hour)
 
 				if _, err := testee.FindRun(
 					ctx, planId, inputKnitId, outputKnitId, status, since, duration,

--- a/cmd/knitd/handlers/run.go
+++ b/cmd/knitd/handlers/run.go
@@ -15,13 +15,15 @@ func FindRunHandler(dbRun kdb.RunInterface) echo.HandlerFunc {
 
 	return func(c echo.Context) error {
 		c.Response().Header().Add("Content-Type", "application/json")
-
 		query, err := func(c echo.Context) (kdb.RunFindQuery, error) {
+
 			result := kdb.RunFindQuery{
 				PlanId:       kstrings.SplitIfNotEmpty(c.QueryParam("plan"), ","),
 				InputKnitId:  kstrings.SplitIfNotEmpty(c.QueryParam("knitIdInput"), ","),
 				OutputKnitId: kstrings.SplitIfNotEmpty(c.QueryParam("knitIdOutput"), ","),
 				Status:       []kdb.KnitRunStatus{},
+				Since:        nil,
+				Duration:     nil,
 			}
 
 			for _, p := range kstrings.SplitIfNotEmpty(c.QueryParam("status"), ",") {
@@ -33,6 +35,16 @@ func FindRunHandler(dbRun kdb.RunInterface) echo.HandlerFunc {
 					)
 				}
 				result.Status = append(result.Status, s)
+			}
+
+			since := c.QueryParam("since")
+			if since != "" {
+				result.Since = &since
+			}
+
+			duration := c.QueryParam("duration")
+			if duration != "" {
+				result.Duration = &duration
 			}
 
 			return result, nil

--- a/cmd/knitd/handlers/run_test.go
+++ b/cmd/knitd/handlers/run_test.go
@@ -37,7 +37,7 @@ func TestRunFindHandler(t *testing.T) {
 		}
 
 		dummySince := "2024-04-01T12:00:00+00:00"
-		dummyDuration := "1 hours"
+		dummyDuration := "2h30m45s"
 
 		for name, testcase := range map[string]struct {
 			when
@@ -45,7 +45,7 @@ func TestRunFindHandler(t *testing.T) {
 		}{
 			"as empty when no runs are found": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -420,7 +420,7 @@ func TestRunFindHandler(t *testing.T) {
 			// duration is assumed to be used in conjunction with since.
 			"when it is queried about since and duration": {
 				when{
-					request: "/api/runs?since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -434,7 +434,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except planId": {
 				when{
-					request: "/api/runs?knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -450,7 +450,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except input knit id": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -466,7 +466,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except output knit id": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -482,7 +482,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except status": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{

--- a/pkg/commandline/flag/flag.go
+++ b/pkg/commandline/flag/flag.go
@@ -3,9 +3,11 @@ package flag
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	apitags "github.com/opst/knitfab/pkg/api/types/tags"
 	"github.com/opst/knitfab/pkg/utils"
+	"github.com/opst/knitfab/pkg/utils/rfctime"
 )
 
 type Argslice []string
@@ -40,5 +42,20 @@ func (t *Tags) Set(v string) error {
 		return err
 	}
 	*t = append(*t, tag)
+	return nil
+}
+
+type LooseRFC3339 time.Time
+
+func (t *LooseRFC3339) String() string {
+	return time.Time(*t).Format(rfctime.RFC3339DateTimeFormatZ)
+}
+
+func (t *LooseRFC3339) Set(v string) error {
+	parsedTime, err := rfctime.ParseLooseRFC3339(v)
+	if err != nil {
+		return err
+	}
+	*t = LooseRFC3339(parsedTime)
 	return nil
 }

--- a/pkg/db/run.go
+++ b/pkg/db/run.go
@@ -403,13 +403,23 @@ type RunFindQuery struct {
 	//
 	// If it is nil or empty, it means "match any".
 	Status []KnitRunStatus
+
+	// match if run's updated time is equal or later than Since.
+	Since *string
+
+	// match if run's updated time is equal or earlier than UpdatedAt + Duration.
+	Duration *string
 }
 
 func (rfq RunFindQuery) Equal(other RunFindQuery) bool {
 	return cmp.SliceContentEq(rfq.PlanId, other.PlanId) &&
 		cmp.SliceContentEq(rfq.InputKnitId, other.InputKnitId) &&
 		cmp.SliceContentEq(rfq.OutputKnitId, other.OutputKnitId) &&
-		cmp.SliceContentEq(rfq.Status, other.Status)
+		cmp.SliceContentEq(rfq.Status, other.Status) &&
+		((rfq.Since == nil && other.Since == nil) ||
+			(rfq.Since != nil && other.Since != nil && *rfq.Since == *other.Since)) &&
+		((rfq.Duration == nil && other.Duration == nil) ||
+			(rfq.Duration != nil && other.Duration != nil && *rfq.Duration == *other.Duration))
 }
 
 // relation between run and data; "How does the run uses data?"

--- a/pkg/utils/rfctime/rfc3339.go
+++ b/pkg/utils/rfctime/rfc3339.go
@@ -73,6 +73,15 @@ func (t RFC3339) String() string {
 	return time.Time(t).Format(RFC3339DateTimeFormat)
 }
 
+// When you need to get string with local timezone, use
+func (t RFC3339) StringWithLocalTimeZone() (string, error) {
+	location, err := time.LoadLocation("Local")
+	if err != nil {
+		return "", err
+	}
+	return time.Time(t).In(location).Format(RFC3339DateTimeFormat), nil
+}
+
 // Parse string to ISO8601 time.
 //
 // It trancates resolution to milli second.
@@ -82,6 +91,19 @@ func ParseRFC3339DateTime(s string) (RFC3339, error) {
 		return *new(RFC3339), err
 	}
 	return RFC3339(t), nil
+}
+
+// when you need to parse multiple formats, use
+func ParseMultipleFormats(s string, formats ...string) (RFC3339, string, error) {
+	var err error
+	var t time.Time
+	for _, format := range formats {
+		t, err = time.Parse(format, s)
+		if err == nil {
+			return RFC3339(t), format, nil
+		}
+	}
+	return *new(RFC3339), "", fmt.Errorf("failed to parse %s", s)
 }
 
 // implement encoding/json.Marshaller

--- a/pkg/utils/rfctime/rfc3339.go
+++ b/pkg/utils/rfctime/rfc3339.go
@@ -18,6 +18,31 @@ const RFC3339DateTimeFormat string = "2006-01-02T15:04:05.999-07:00"
 // Use it to parse RFC3339 date-time expression.
 const RFC3339DateTimeFormatZ string = time.RFC3339Nano
 
+// The following format is used to parse the abbreviated form of RFC3339 date-time.
+const (
+	RFC3339DateNano       = "2006-01-02T15:04:05.999999999"
+	RFC3339DateNanoNoDeL  = "2006-01-02 15:04:05.999999999"
+	RFC3339DateNanoZNoDeL = "2006-01-02 15:04:05.999999999Z07:00"
+
+	RFC3339DateSec       = "2006-01-02T15:04:05"
+	RFC3339DateSecZ      = "2006-01-02T15:04:05Z07:00"
+	RFC3339DateSecNoDeL  = "2006-01-02 15:04:05"
+	RFC3339DateSecZNoDeL = "2006-01-02 15:04:05Z07:00"
+
+	RFC3339DateMin       = "2006-01-02T15:04"
+	RFC3339DateMinZ      = "2006-01-02T15:04Z07:00"
+	RFC3339DateMinNoDeL  = "2006-01-02 15:04"
+	RFC3339DateMinZNoDeL = "2006-01-02 15:04Z07:00"
+
+	RFC3339DateHour       = "2006-01-02T15"
+	RFC3339DateHourZ      = "2006-01-02T15Z07:00"
+	RFC3339DateHourNoDeL  = "2006-01-02 15"
+	RFC3339DateHourZNoDeL = "2006-01-02 15Z07:00"
+
+	RFC3339DateOnly  = "2006-01-02"
+	RFC3339DateOnlyZ = "2006-01-02Z07:00"
+)
+
 // date-time in https://www.ietf.org/rfc/rfc3339.txt .
 // this is known as a subset of ISO8601 extended format.
 //
@@ -93,17 +118,45 @@ func ParseRFC3339DateTime(s string) (RFC3339, error) {
 	return RFC3339(t), nil
 }
 
-// when you need to parse multiple formats, use
-func ParseMultipleFormats(s string, formats ...string) (RFC3339, string, error) {
-	var err error
-	var t time.Time
+// When you need to parse string with the abbreviated forms of RFC3339 date-time, use this function.
+func ParseLooseRFC3339(s string) (RFC3339, error) {
+	// get local timezone
+	location, err := time.LoadLocation("Local")
+	if err != nil {
+		return RFC3339{}, err
+	}
+
+	formats := []string{
+		RFC3339DateTimeFormatZ, RFC3339DateNanoZNoDeL,
+		RFC3339DateSecZ, RFC3339DateSecZNoDeL,
+		RFC3339DateMinZ, RFC3339DateMinZNoDeL,
+		RFC3339DateHourZ, RFC3339DateHourZNoDeL,
+		RFC3339DateOnlyZ,
+	}
+
 	for _, format := range formats {
-		t, err = time.Parse(format, s)
+		t, err := time.Parse(format, s)
 		if err == nil {
-			return RFC3339(t), format, nil
+			return RFC3339(t), nil
 		}
 	}
-	return *new(RFC3339), "", fmt.Errorf("failed to parse %s", s)
+
+	formatsWithoutTimeZone := []string{
+		RFC3339DateNano, RFC3339DateNanoNoDeL,
+		RFC3339DateSec, RFC3339DateSecNoDeL,
+		RFC3339DateMin, RFC3339DateMinNoDeL,
+		RFC3339DateHour, RFC3339DateHourNoDeL,
+		RFC3339DateOnly,
+	}
+
+	for _, format := range formatsWithoutTimeZone {
+		t, err := time.ParseInLocation(format, s, location)
+		if err == nil {
+			return RFC3339(t), nil
+		}
+	}
+
+	return RFC3339{}, fmt.Errorf("failed to parse %s", s)
 }
 
 // implement encoding/json.Marshaller

--- a/pkg/utils/rfctime/rfc3339_test.go
+++ b/pkg/utils/rfctime/rfc3339_test.go
@@ -115,3 +115,179 @@ func Test_StringWithLocalTimeZone(t *testing.T) {
 		}
 	})
 }
+
+func Test_ParseLooseRFC3339(t *testing.T) {
+	type when struct {
+		args []string
+	}
+	type then struct {
+		expected []time.Time
+	}
+
+	theory := func(when when, then then) func(*testing.T) {
+		return func(t *testing.T) {
+			for i, w := range when.args {
+				testee, err := rfctime.ParseLooseRFC3339(w)
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectdRFC3339 := rfctime.RFC3339(then.expected[i])
+
+				if !testee.Time().Equal(then.expected[i]) {
+					t.Errorf("unmatch: as time: (actual, expected) = (%+v, %+v)", testee, then.expected[i])
+				}
+
+				if !testee.Equiv(expectdRFC3339) {
+					t.Errorf("unmatch: as RFC3339: (actual, expected) = (%+v, %+v)", testee, expectdRFC3339)
+				}
+			}
+		}
+	}
+
+	t.Run("it should parse when passed RFC3339DateNano format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12:34:56.987654321+07:00",
+				"2024-04-22 12:34:56.987654321+07:00",
+				"2024-04-22T12:34:56.987654321",
+				"2024-04-22 12:34:56.987654321",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	//
+	t.Run("it should parse when passed RFC3339DateSec format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12:34:56+07:00",
+				"2024-04-22 12:34:56+07:00",
+				"2024-04-22T12:34:56",
+				"2024-04-22 12:34:56",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	t.Run("it should parse when passed RFC3339DateMin format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12:34+07:00",
+				"2024-04-22 12:34+07:00",
+				"2024-04-22T12:34",
+				"2024-04-22 12:34",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	t.Run("it should parse when passed RFC3339DateHour format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12+07:00",
+				"2024-04-22 12+07:00",
+				"2024-04-22T12",
+				"2024-04-22 12",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	t.Run("it should parse when passed RFC3339DateOnly format", theory(
+		when{
+			args: []string{
+				"2024-04-22+07:00",
+				"2024-04-22",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 00, 00, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 0, 00, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+}

--- a/pkg/utils/rfctime/rfc3339_test.go
+++ b/pkg/utils/rfctime/rfc3339_test.go
@@ -99,3 +99,19 @@ func TestRFC3339(t *testing.T) {
 		})
 	})
 }
+func Test_StringWithLocalTimeZone(t *testing.T) {
+	t.Run("it should return local time zone when passed format without local time zone", func(t *testing.T) {
+		s := "2024-04-02"
+		testee := rfctime.RFC3339(try.To(time.Parse(time.DateOnly, s)).OrFatal(t))
+
+		actual, err := testee.StringWithLocalTimeZone()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := "2024-04-02T09:00:00+09:00"
+		if actual != expected {
+			t.Errorf("unmatch: (actual, expected) = (%s, %s)", actual, expected)
+		}
+	})
+}


### PR DESCRIPTION
# This PR

Enable querying by the range of updated_at in `knit run find.

Add new  two flags, `--since` and `--duration`.

## `--since`
Since can be described in RFC3339 date-time format, and it is also possible to omit sub-seconds,seconds, minutes, and hours, in the description.
If the time zone is omitted, the local time zone is applied. 
When including a date and time, the following characters are allowed as delimiters between the date and time: `T` or space.
 
## `--duration`
Duration is a flag used in conjunction with `--since`. 
Duration can be described in Go's time.Duration type.
Examples of duration are "300ms", "1.5h" or "2h45m".

## Related Issue
close #22