### PR TITLE
Feature/#19/data find time based query

### DIFF
--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -204,7 +204,7 @@ type KnitClient interface {
 	// - error
 	GetRunLog(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
 
-	// FindRun find run with given planId, knitId and status.
+	// FindRun find run with given planId, knitId, status, since and duration.
 
 	// Args
 	//
@@ -218,13 +218,18 @@ type KnitClient interface {
 	//
 	// - []string: status which run to be found is
 	//
+	// - string: since which updated time of run to be found is after
+	//
+	// - string: duration which updated time of run to be found is within
+	//
 	// Returns
 	//
 	// - []apirun.Detail: metadata of found run
 	//
 	// - error
 	FindRun(
-		ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string,
+		ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string,
+		status []string, since string, duration string,
 	) ([]apirun.Detail, error)
 
 	// Abort abort run with given runId.

--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -111,12 +111,16 @@ type KnitClient interface {
 	//
 	// - []apitag.Tag: tags which data to be found has.
 	//
+	// - time.Time: The updated time of the run to be found is after.
+	//
+	// - time.duration: duration which updated time of run to be found is within
+	//
 	// Returns
 	//
 	// - []apidata.Detail: metadata of found data
 	//
 	// - error
-	FindData(ctx context.Context, tag []apitag.Tag) ([]apidata.Detail, error)
+	FindData(ctx context.Context, tag []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error)
 
 	// GetPlan get plan detail with given planId.
 	//

--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	kprof "github.com/opst/knitfab/cmd/knit/config/profiles"
 	apidata "github.com/opst/knitfab/pkg/api/types/data"
@@ -218,9 +219,9 @@ type KnitClient interface {
 	//
 	// - []string: status which run to be found is
 	//
-	// - string: since which updated time of run to be found is after
+	// - time.Time: time which updated time of run to be found is after
 	//
-	// - string: duration which updated time of run to be found is within
+	// - time.duration: duration which updated time of run to be found is within
 	//
 	// Returns
 	//
@@ -229,7 +230,7 @@ type KnitClient interface {
 	// - error
 	FindRun(
 		ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string,
-		status []string, since string, duration string,
+		status []string, since time.Time, duration time.Duration,
 	) ([]apirun.Detail, error)
 
 	// Abort abort run with given runId.

--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -26,12 +26,18 @@ type Unit interface{}
 
 // struct that contains the arguments for FindRun
 type FindRunParameter struct {
-	PlanId    []string
-	KnitIdIn  []string
+	// planId which run to be found has
+	PlanId []string
+	// knitId which run to be found has as input
+	KnitIdIn []string
+	// knitId which run to be found has as output
 	KnitIdOut []string
-	Status    []string
-	Since     *time.Time
-	Duration  *time.Duration
+	// status which run to be found is
+	Status []string
+	// time which updated time of run to be found is equal or later than
+	Since *time.Time
+	// duration which updated time of run to be found is within
+	Duration *time.Duration
 }
 
 var ValUnit Unit = struct{}{}
@@ -215,25 +221,13 @@ type KnitClient interface {
 	// - error
 	GetRunLog(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
 
-	// FindRun find run with RunFindQuery.
+	// FindRun find run with FindRunParameter.
 
 	// Args
 	//
 	// - context.Context
 	//
-	// - RunFindQuery :
-	//
-	//   - []string: planId which run to be found has
-	//
-	//   - []string: knitId which run to be found has as input
-	//
-	//   - []string: knitId which run to be found has as output
-	//
-	//   - []string: status which run to be found is
-	//
-	//   - time.Time: time which updated time of run to be found is later
-	//
-	//   - time.duration: duration which updated time of run to be found is within
+	// - FindRunParameter
 	//
 	// Returns
 	//

--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -24,6 +24,16 @@ import (
 // meaningless value
 type Unit interface{}
 
+// struct that contains the arguments for FindRun
+type FindRunParameter struct {
+	PlanId    []string
+	KnitIdIn  []string
+	KnitIdOut []string
+	Status    []string
+	Since     *time.Time
+	Duration  *time.Duration
+}
+
 var ValUnit Unit = struct{}{}
 
 type KnitClient interface {
@@ -205,33 +215,32 @@ type KnitClient interface {
 	// - error
 	GetRunLog(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
 
-	// FindRun find run with given planId, knitId, status, since and duration.
+	// FindRun find run with RunFindQuery.
 
 	// Args
 	//
 	// - context.Context
 	//
-	// - []string: planId which run to be found has
+	// - RunFindQuery :
 	//
-	// - []string: knitId which run to be found has as input
+	//   - []string: planId which run to be found has
 	//
-	// - []string: knitId which run to be found has as output
+	//   - []string: knitId which run to be found has as input
 	//
-	// - []string: status which run to be found is
+	//   - []string: knitId which run to be found has as output
 	//
-	// - time.Time: time which updated time of run to be found is after
+	//   - []string: status which run to be found is
 	//
-	// - time.duration: duration which updated time of run to be found is within
+	//   - time.Time: time which updated time of run to be found is later
+	//
+	//   - time.duration: duration which updated time of run to be found is within
 	//
 	// Returns
 	//
 	// - []apirun.Detail: metadata of found run
 	//
 	// - error
-	FindRun(
-		ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string,
-		status []string, since time.Time, duration time.Duration,
-	) ([]apirun.Detail, error)
+	FindRun(context.Context, FindRunParameter) ([]apirun.Detail, error)
 
 	// Abort abort run with given runId.
 	//

--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -111,7 +111,7 @@ type KnitClient interface {
 	//
 	// - []apitag.Tag: tags which data to be found has.
 	//
-	// - time.Time: The updated time of the run to be found is after.
+	// - time.Time: The updated time of the run to be found is later.
 	//
 	// - time.duration: duration which updated time of run to be found is within
 	//
@@ -120,7 +120,7 @@ type KnitClient interface {
 	// - []apidata.Detail: metadata of found data
 	//
 	// - error
-	FindData(ctx context.Context, tag []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error)
+	FindData(ctx context.Context, tag []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error)
 
 	// GetPlan get plan detail with given planId.
 	//

--- a/cmd/knit/rest/data.go
+++ b/cmd/knit/rest/data.go
@@ -310,7 +310,7 @@ func (ci *client) GetData(ctx context.Context, knitid string, handler func(FileE
 	})
 }
 
-func (c *client) FindData(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+func (c *client) FindData(ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apipath("data"), nil)
 	if err != nil {
@@ -320,17 +320,17 @@ func (c *client) FindData(ctx context.Context, tags []apitag.Tag, since time.Tim
 	// set query values
 	q := req.URL.Query()
 
-	sinceStr := ""
-	if since != (time.Time{}) {
-		sinceStr = since.Format(rfctime.RFC3339DateTimeFormatZ)
+	sinceString := ""
+	if since != nil {
+		sinceString = since.Format(rfctime.RFC3339DateTimeFormatZ)
 	}
-	q.Add("since", sinceStr)
+	q.Add("since", sinceString)
 
-	durationStr := ""
-	if duration != 0 {
-		durationStr = duration.String()
+	durationString := ""
+	if duration != nil {
+		durationString = duration.String()
 	}
-	q.Add("duration", durationStr)
+	q.Add("duration", durationString)
 
 	tagcount := len(tags)
 	if 0 < tagcount {

--- a/cmd/knit/rest/data_test.go
+++ b/cmd/knit/rest/data_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	kprof "github.com/opst/knitfab/cmd/knit/config/profiles"
 	krst "github.com/opst/knitfab/cmd/knit/rest"
@@ -541,28 +542,45 @@ func TestFindData(t *testing.T) {
 			return h, func() *http.Request { return request }
 		}
 
+		type when struct {
+			tags     []apitag.Tag
+			since    time.Time
+			duration time.Duration
+		}
+
 		type then struct {
-			tagsInQuery []string
+			tagsInQuery   []string
+			sinceQuery    string
+			durationQuery string
 		}
 
 		type testcase struct {
-			when []apitag.Tag
+			when when
 			then then
 		}
 
 		for name, testcase := range map[string]testcase{
 			"when query with no tags, server receives empty query string": {
-				when: []apitag.Tag{},
+				when: when{},
 				then: then{
-					tagsInQuery: []string{},
+					tagsInQuery:   []string{},
+					sinceQuery:    "",
+					durationQuery: "",
 				},
 			},
 			"when query with tags, server receives them": {
-				when: []apitag.Tag{
-					{Key: "key-a", Value: "value/a"},
-					{Key: "type", Value: "unknown?"},
-					{Key: "knit#id", Value: "some-knit-id"},
-					{Key: "owner", Value: "100% our-team&client, of cource!"},
+				when: when{
+					tags: []apitag.Tag{
+						{Key: "key-a", Value: "value/a"},
+						{Key: "type", Value: "unknown?"},
+						{Key: "knit#id", Value: "some-knit-id"},
+						{Key: "owner", Value: "100% our-team&client, of cource!"},
+					},
+					since: time.Date(
+						2024, 4, 22, 12, 34, 56, 987654321,
+						time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+					),
+					duration: time.Duration(2 * time.Hour),
 				},
 				then: then{
 					// metachar: '/' '#' '?' '&' '%', ' '(space) and ',
@@ -572,6 +590,8 @@ func TestFindData(t *testing.T) {
 						"knit#id:some-knit-id",
 						"owner:100% our-team&client, of cource!",
 					},
+					sinceQuery:    "2024-04-22T12:34:56.987654321+07:00",
+					durationQuery: "2h0m0s",
 				},
 			},
 		} {
@@ -586,8 +606,11 @@ func TestFindData(t *testing.T) {
 				// prepare for the tests
 				profile := kprof.KnitProfile{ApiRoot: ts.URL}
 
+				when := testcase.when
+				then := testcase.then
+
 				testee := try.To(krst.NewClient(&profile)).OrFatal(t)
-				result := try.To(testee.FindData(ctx, testcase.when)).OrFatal(t)
+				result := try.To(testee.FindData(ctx, when.tags, when.since, when.duration)).OrFatal(t)
 
 				if !cmp.SliceContentEqWith(
 					utils.RefOf(result), utils.RefOf(response),
@@ -605,10 +628,10 @@ func TestFindData(t *testing.T) {
 				}
 
 				actualTags := getLastRequest().URL.Query()["tag"]
-				if !cmp.SliceContentEq(actualTags, testcase.then.tagsInQuery) {
+				if !cmp.SliceContentEq(actualTags, then.tagsInQuery) {
 					t.Errorf(
 						"query tags is wrong:\n- actual  : %s\n- expected: %s",
-						actualTags, testcase.then.tagsInQuery,
+						actualTags, then.tagsInQuery,
 					)
 				}
 
@@ -794,8 +817,14 @@ func TestFindData(t *testing.T) {
 				{Key: "tag-a", Value: "value-a"},
 			}
 
+			since := time.Date(
+				2024, 4, 22, 12, 34, 56, 000000000,
+				time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+			)
+			duration := time.Duration(2 * time.Hour)
+
 			testee := try.To(krst.NewClient(&profile)).OrFatal(t)
-			actualResponse := try.To(testee.FindData(ctx, queryTags)).OrFatal(t)
+			actualResponse := try.To(testee.FindData(ctx, queryTags, since, duration)).OrFatal(t)
 
 			if !cmp.SliceContentEqWith(
 				actualResponse, expectedResponse,
@@ -840,7 +869,13 @@ func TestFindData(t *testing.T) {
 					{Key: "tag-a", Value: "value-a"},
 				}
 
-				if _, err := testee.FindData(ctx, queryTags); err == nil {
+				since := time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				)
+				duration := time.Duration(2 * time.Hour)
+
+				if _, err := testee.FindData(ctx, queryTags, since, duration); err == nil {
 					t.Errorf("no error occured")
 				}
 

--- a/cmd/knit/rest/data_test.go
+++ b/cmd/knit/rest/data_test.go
@@ -544,8 +544,8 @@ func TestFindData(t *testing.T) {
 
 		type when struct {
 			tags     []apitag.Tag
-			since    time.Time
-			duration time.Duration
+			since    *time.Time
+			duration *time.Duration
 		}
 
 		type then struct {
@@ -558,6 +558,9 @@ func TestFindData(t *testing.T) {
 			when when
 			then then
 		}
+
+		since := try.To(rfctime.ParseRFC3339DateTime("2024-04-22T12:34:56.987654321+07:00")).OrFatal(t).Time()
+		duration := time.Duration(2 * time.Hour)
 
 		for name, testcase := range map[string]testcase{
 			"when query with no tags, server receives empty query string": {
@@ -576,11 +579,8 @@ func TestFindData(t *testing.T) {
 						{Key: "knit#id", Value: "some-knit-id"},
 						{Key: "owner", Value: "100% our-team&client, of cource!"},
 					},
-					since: time.Date(
-						2024, 4, 22, 12, 34, 56, 987654321,
-						time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
-					),
-					duration: time.Duration(2 * time.Hour),
+					since:    &since,
+					duration: &duration,
 				},
 				then: then{
 					// metachar: '/' '#' '?' '&' '%', ' '(space) and ',
@@ -817,14 +817,11 @@ func TestFindData(t *testing.T) {
 				{Key: "tag-a", Value: "value-a"},
 			}
 
-			since := time.Date(
-				2024, 4, 22, 12, 34, 56, 000000000,
-				time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
-			)
+			since := try.To(rfctime.ParseRFC3339DateTime("2024-04-22T12:34:56.987654321+07:00")).OrFatal(t).Time()
 			duration := time.Duration(2 * time.Hour)
 
 			testee := try.To(krst.NewClient(&profile)).OrFatal(t)
-			actualResponse := try.To(testee.FindData(ctx, queryTags, since, duration)).OrFatal(t)
+			actualResponse := try.To(testee.FindData(ctx, queryTags, &since, &duration)).OrFatal(t)
 
 			if !cmp.SliceContentEqWith(
 				actualResponse, expectedResponse,
@@ -869,13 +866,10 @@ func TestFindData(t *testing.T) {
 					{Key: "tag-a", Value: "value-a"},
 				}
 
-				since := time.Date(
-					2024, 4, 22, 12, 34, 56, 000000000,
-					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
-				)
+				since := try.To(rfctime.ParseRFC3339DateTime("2024-04-22T12:34:56.987654321+07:00")).OrFatal(t).Time()
 				duration := time.Duration(2 * time.Hour)
 
-				if _, err := testee.FindData(ctx, queryTags, since, duration); err == nil {
+				if _, err := testee.FindData(ctx, queryTags, &since, &duration); err == nil {
 					t.Errorf("no error occured")
 				}
 

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/opst/knitfab/cmd/knit/rest"
 	apidata "github.com/opst/knitfab/pkg/api/types/data"
@@ -35,8 +36,8 @@ type FindRunArgs struct {
 	KnitIdIn  []string
 	KnitIdOut []string
 	status    []string
-	since     string
-	duration  string
+	since     time.Time
+	duration  time.Duration
 }
 
 func New(t *testing.T) *mockKnitClient {
@@ -107,7 +108,7 @@ type mockKnitClient struct {
 		RegisterPlan       func(ctx context.Context, spec apiplans.PlanSpec) (apiplans.Detail, error)
 		GetRun             func(ctx context.Context, runId string) (apirun.Detail, error)
 		GetRunLog          func(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
-		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string, since, duration string) ([]apirun.Detail, error)
+		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string, since time.Time, duration time.Duration) ([]apirun.Detail, error)
 		Abort              func(ctx context.Context, runId string) (apirun.Detail, error)
 		Tearoff            func(ctx context.Context, runId string) (apirun.Detail, error)
 		DeleteRun          func(ctx context.Context, runId string) error
@@ -285,8 +286,8 @@ func (m *mockKnitClient) FindRun(
 	knitIdIn []string,
 	knitIdOut []string,
 	status []string,
-	since string,
-	duration string,
+	since time.Time,
+	duration time.Duration,
 ) ([]apirun.Detail, error) {
 	m.t.Helper()
 

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -31,6 +31,12 @@ type FindPlanArgs struct {
 	OutTags  []apitags.Tag
 }
 
+type FindDataArgs struct {
+	Tags     []apitags.Tag
+	since    time.Time
+	duration time.Duration
+}
+
 type FindRunArgs struct {
 	planId    []string
 	KnitIdIn  []string
@@ -97,7 +103,7 @@ type mockKnitClient struct {
 		PutTagsForData func(knitId string, tags apitags.Change) (*apidata.Detail, error)
 		GetDataRaw     func(context.Context, string, func(io.Reader) error) error
 		GetData        func(context.Context, string, func(rest.FileEntry) error) error
-		FindData       func(context.Context, []apitags.Tag) ([]apidata.Detail, error)
+		FindData       func(ctx context.Context, tags []apitags.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error)
 		GetPlans       func(ctx context.Context, planId string) (apiplans.Detail, error)
 		FindPlan       func(
 			ctx context.Context, active logic.Ternary, imageVer kdb.ImageIdentifier,
@@ -119,7 +125,7 @@ type mockKnitClient struct {
 		PutTagsForData     []PutTagsForDataArgs
 		GetDataRaw         []string
 		GetData            []string
-		FindData           [][]apitags.Tag
+		FindData           []FindDataArgs
 		GetPlans           []string
 		Findplan           []FindPlanArgs
 		PutPlanForActivate []string
@@ -184,15 +190,18 @@ func (m *mockKnitClient) GetData(ctx context.Context, knitId string, handler fun
 	return m.Impl.GetData(ctx, knitId, handler)
 }
 
-func (m *mockKnitClient) FindData(ctx context.Context, tags []apitags.Tag) ([]apidata.Detail, error) {
+func (m *mockKnitClient) FindData(ctx context.Context, tags []apitags.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
 	m.t.Helper()
 
-	m.Calls.FindData = append(m.Calls.FindData, tags)
+	m.Calls.FindData = append(
+		m.Calls.FindData,
+		FindDataArgs{tags, since, duration},
+	)
 
 	if m.Impl.FindData == nil {
 		m.t.Fatal("FindData is not ready to be called")
 	}
-	return m.Impl.FindData(ctx, tags)
+	return m.Impl.FindData(ctx, tags, since, duration)
 }
 
 func (m *mockKnitClient) GetPlans(ctx context.Context, planId string) (apiplans.Detail, error) {

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -108,7 +108,7 @@ type mockKnitClient struct {
 		RegisterPlan       func(ctx context.Context, spec apiplans.PlanSpec) (apiplans.Detail, error)
 		GetRun             func(ctx context.Context, runId string) (apirun.Detail, error)
 		GetRunLog          func(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
-		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string, since time.Time, duration time.Duration) ([]apirun.Detail, error)
+		FindRun            func(ctx context.Context, query rest.FindRunParameter) ([]apirun.Detail, error)
 		Abort              func(ctx context.Context, runId string) (apirun.Detail, error)
 		Tearoff            func(ctx context.Context, runId string) (apirun.Detail, error)
 		DeleteRun          func(ctx context.Context, runId string) error
@@ -282,23 +282,18 @@ func (m *mockKnitClient) GetRunLog(ctx context.Context, runId string, follow boo
 
 func (m *mockKnitClient) FindRun(
 	ctx context.Context,
-	planId []string,
-	knitIdIn []string,
-	knitIdOut []string,
-	status []string,
-	since time.Time,
-	duration time.Duration,
+	query rest.FindRunParameter,
 ) ([]apirun.Detail, error) {
 	m.t.Helper()
 
 	m.Calls.FindRun = append(
 		m.Calls.FindRun,
-		FindRunArgs{planId, knitIdIn, knitIdOut, status, since, duration},
+		FindRunArgs{query.PlanId, query.KnitIdIn, query.KnitIdOut, query.Status, *query.Since, *query.Duration},
 	)
 	if m.Impl.FindRun == nil {
 		m.t.Fatal("FindRun is not ready to be called")
 	}
-	return m.Impl.FindRun(ctx, planId, knitIdIn, knitIdOut, status, since, duration)
+	return m.Impl.FindRun(ctx, query)
 }
 
 func (m *mockKnitClient) Abort(ctx context.Context, runId string) (apirun.Detail, error) {

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -33,8 +33,8 @@ type FindPlanArgs struct {
 
 type FindDataArgs struct {
 	Tags     []apitags.Tag
-	since    time.Time
-	duration time.Duration
+	since    *time.Time
+	duration *time.Duration
 }
 
 type FindRunArgs struct {
@@ -103,7 +103,7 @@ type mockKnitClient struct {
 		PutTagsForData func(knitId string, tags apitags.Change) (*apidata.Detail, error)
 		GetDataRaw     func(context.Context, string, func(io.Reader) error) error
 		GetData        func(context.Context, string, func(rest.FileEntry) error) error
-		FindData       func(ctx context.Context, tags []apitags.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error)
+		FindData       func(ctx context.Context, tags []apitags.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error)
 		GetPlans       func(ctx context.Context, planId string) (apiplans.Detail, error)
 		FindPlan       func(
 			ctx context.Context, active logic.Ternary, imageVer kdb.ImageIdentifier,
@@ -190,7 +190,7 @@ func (m *mockKnitClient) GetData(ctx context.Context, knitId string, handler fun
 	return m.Impl.GetData(ctx, knitId, handler)
 }
 
-func (m *mockKnitClient) FindData(ctx context.Context, tags []apitags.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+func (m *mockKnitClient) FindData(ctx context.Context, tags []apitags.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 	m.t.Helper()
 
 	m.Calls.FindData = append(

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -35,6 +35,8 @@ type FindRunArgs struct {
 	KnitIdIn  []string
 	KnitIdOut []string
 	status    []string
+	since     string
+	duration  string
 }
 
 func New(t *testing.T) *mockKnitClient {
@@ -105,7 +107,7 @@ type mockKnitClient struct {
 		RegisterPlan       func(ctx context.Context, spec apiplans.PlanSpec) (apiplans.Detail, error)
 		GetRun             func(ctx context.Context, runId string) (apirun.Detail, error)
 		GetRunLog          func(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
-		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string) ([]apirun.Detail, error)
+		FindRun            func(ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string, since, duration string) ([]apirun.Detail, error)
 		Abort              func(ctx context.Context, runId string) (apirun.Detail, error)
 		Tearoff            func(ctx context.Context, runId string) (apirun.Detail, error)
 		DeleteRun          func(ctx context.Context, runId string) error
@@ -278,18 +280,24 @@ func (m *mockKnitClient) GetRunLog(ctx context.Context, runId string, follow boo
 }
 
 func (m *mockKnitClient) FindRun(
-	ctx context.Context, planId []string, knitIdIn []string, knitIdOut []string, status []string,
+	ctx context.Context,
+	planId []string,
+	knitIdIn []string,
+	knitIdOut []string,
+	status []string,
+	since string,
+	duration string,
 ) ([]apirun.Detail, error) {
 	m.t.Helper()
 
 	m.Calls.FindRun = append(
 		m.Calls.FindRun,
-		FindRunArgs{planId, knitIdIn, knitIdOut, status},
+		FindRunArgs{planId, knitIdIn, knitIdOut, status, since, duration},
 	)
 	if m.Impl.FindRun == nil {
 		m.t.Fatal("FindRun is not ready to be called")
 	}
-	return m.Impl.FindRun(ctx, planId, knitIdIn, knitIdOut, status)
+	return m.Impl.FindRun(ctx, planId, knitIdIn, knitIdOut, status, since, duration)
 }
 
 func (m *mockKnitClient) Abort(ctx context.Context, runId string) (apirun.Detail, error) {

--- a/cmd/knit/rest/run.go
+++ b/cmd/knit/rest/run.go
@@ -69,6 +69,8 @@ func (c *client) FindRun(
 	knitIdIn []string,
 	knitIdOut []string,
 	status []string,
+	since string,
+	duration string,
 ) ([]apirun.Detail, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apipath("runs"), nil)
@@ -83,6 +85,8 @@ func (c *client) FindRun(
 		"knitIdInput":  knitIdIn,
 		"knitIdOutput": knitIdOut,
 		"status":       status,
+		"since":        {since},
+		"duration":     {duration},
 	}
 	for key, value := range paramMap {
 		if len(value) > 0 {

--- a/cmd/knit/rest/run.go
+++ b/cmd/knit/rest/run.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	apirun "github.com/opst/knitfab/pkg/api/types/runs"
+	"github.com/opst/knitfab/pkg/utils/rfctime"
 )
 
 func (c *client) GetRun(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -69,13 +71,27 @@ func (c *client) FindRun(
 	knitIdIn []string,
 	knitIdOut []string,
 	status []string,
-	since string,
-	duration string,
+	since time.Time,
+	duration time.Duration,
 ) ([]apirun.Detail, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apipath("runs"), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	var sinceStr string
+	if since != (time.Time{}) {
+		sinceStr = since.Format(rfctime.RFC3339DateTimeFormatZ)
+	} else {
+		sinceStr = ""
+	}
+
+	var durationStr string
+	if duration != 0 {
+		durationStr = duration.String()
+	} else {
+		durationStr = ""
 	}
 
 	// set query values
@@ -85,8 +101,8 @@ func (c *client) FindRun(
 		"knitIdInput":  knitIdIn,
 		"knitIdOutput": knitIdOut,
 		"status":       status,
-		"since":        {since},
-		"duration":     {duration},
+		"since":        {sinceStr},
+		"duration":     {durationStr},
 	}
 	for key, value := range paramMap {
 		if len(value) > 0 {

--- a/cmd/knit/rest/run_test.go
+++ b/cmd/knit/rest/run_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	kprof "github.com/opst/knitfab/cmd/knit/config/profiles"
 	krst "github.com/opst/knitfab/cmd/knit/rest"
@@ -320,8 +321,8 @@ func TestFindRun(t *testing.T) {
 			knitIdIn  []string
 			knitIdOut []string
 			status    []string
-			since     string
-			duration  string
+			since     time.Time
+			duration  time.Duration
 		}
 
 		type then struct {
@@ -345,8 +346,8 @@ func TestFindRun(t *testing.T) {
 					knitIdIn:  []string{},
 					knitIdOut: []string{},
 					status:    []string{},
-					since:     "",
-					duration:  "",
+					since:     time.Time{},
+					duration:  time.Duration(0),
 				},
 				then: then{
 					planIdInQuery:    []string{},
@@ -363,16 +364,19 @@ func TestFindRun(t *testing.T) {
 					knitIdIn:  []string{"in-a", "in-b"},
 					knitIdOut: []string{"out-a", "out-b"},
 					status:    []string{"wating", "running"},
-					since:     "2024-04-02T12:00:00+00:00",
-					duration:  "2 hours",
+					since: time.Date(
+						2024, 4, 22, 12, 34, 56, 987654321,
+						time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+					),
+					duration: time.Duration(2 * time.Hour),
 				},
 				then: then{
 					planIdInQuery:    []string{"test-a,test-b"},
 					knitIdInInQuery:  []string{"in-a,in-b"},
 					knitIdOutInQuery: []string{"out-a,out-b"},
 					statusInQuery:    []string{"wating,running"},
-					sinceQuery:       "2024-04-02T12:00:00+00:00",
-					durationQuery:    "2 hours",
+					sinceQuery:       "2024-04-22T12:34:56.987654321+07:00",
+					durationQuery:    "2h0m0s",
 				},
 			},
 		} {
@@ -456,8 +460,11 @@ func TestFindRun(t *testing.T) {
 			inputKnitId := []string{"test-inputKnitId"}
 			outputKnitId := []string{"test-outputKnitId"}
 			status := []string{"test-status"}
-			since := "2024-04-02T12:00:00+00:00"
-			duration := "2 hours"
+			since := time.Date(
+				2024, 4, 22, 12, 34, 56, 000000000,
+				time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+			)
+			duration := time.Duration(2 * time.Hour)
 
 			//test start
 			actualResponse := try.To(
@@ -515,8 +522,11 @@ func TestFindRun(t *testing.T) {
 				inputKnitId := []string{"test-inputKnitId"}
 				outputKnitId := []string{"test-outputKnitId"}
 				status := []string{"test-status"}
-				since := "2024-04-02T12:00:00+00:00"
-				duration := "2 hours"
+				since := time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				)
+				duration := time.Duration(2 * time.Hour)
 
 				if _, err := testee.FindRun(
 					ctx, planId, inputKnitId, outputKnitId, status, since, duration,

--- a/cmd/knit/subcommands/data/find/command_test.go
+++ b/cmd/knit/subcommands/data/find/command_test.go
@@ -81,8 +81,8 @@ func TestFindDataCommand(t *testing.T) {
 				_ krst.KnitClient,
 				tags []apitags.Tag,
 				transient data_find.TransientValue,
-				since time.Time,
-				duration time.Duration,
+				since *time.Time,
+				duration *time.Duration,
 			) ([]apidata.Detail, error) {
 				if !cmp.SliceContentEqWith(
 					tags, then.tags,
@@ -677,12 +677,15 @@ func TestFindData(t *testing.T) {
 			ctx := context.Background()
 			logger := logger.Null()
 			mock := mock.New(t)
-			mock.Impl.FindData = func(ctx context.Context, t []apitags.Tag, s time.Time, d time.Duration) ([]apidata.Detail, error) {
+			mock.Impl.FindData = func(ctx context.Context, t []apitags.Tag, s *time.Time, d *time.Duration) ([]apidata.Detail, error) {
 				return testcase.given, nil
 			}
 
+			since := try.To(rfctime.ParseRFC3339DateTime("2024-04-22T00:00:00.000+09:00")).OrFatal(t).Time()
+			duration := time.Duration(2 * time.Hour)
+
 			actual := try.To(data_find.RunFindData(
-				ctx, logger, mock, testcase.when.tags, testcase.when.transientFlag, time.Time{}, time.Duration(0),
+				ctx, logger, mock, testcase.when.tags, testcase.when.transientFlag, &since, &duration,
 			)).OrFatal(t)
 
 			{
@@ -730,12 +733,15 @@ func TestFindData(t *testing.T) {
 		expectedError := errors.New("fake error")
 
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, t []apitags.Tag, s time.Time, d time.Duration) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, t []apitags.Tag, s *time.Time, d *time.Duration) ([]apidata.Detail, error) {
 			return nil, expectedError
 		}
 
+		since := try.To(rfctime.ParseRFC3339DateTime("2024-04-22T00:00:00.000+09:00")).OrFatal(t).Time()
+		duration := time.Duration(2 * time.Hour)
+
 		actual, err := data_find.RunFindData(
-			ctx, logger, mock, []apitags.Tag{}, data_find.TransientAny, time.Time{}, time.Duration(0),
+			ctx, logger, mock, []apitags.Tag{}, data_find.TransientAny, &since, &duration,
 		)
 
 		if len(actual) != 0 {

--- a/cmd/knit/subcommands/data/lineage/command.go
+++ b/cmd/knit/subcommands/data/lineage/command.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	kcmd "github.com/opst/knitfab/cmd/knit/commandline/command"
 	kenv "github.com/opst/knitfab/cmd/knit/env"
@@ -772,7 +771,7 @@ func TraceUpstreamForSingleNode(
 }
 
 func getData(ctx context.Context, client krst.KnitClient, knitId string) (apidata.Detail, error) {
-	datas, err := client.FindData(ctx, []apitag.Tag{knitIdTag(knitId)}, time.Time{}, 0)
+	datas, err := client.FindData(ctx, []apitag.Tag{knitIdTag(knitId)}, nil, nil)
 	if err != nil {
 		return apidata.Detail{}, ErrFindDataWithKnitId(knitId, err)
 	}

--- a/cmd/knit/subcommands/data/lineage/command.go
+++ b/cmd/knit/subcommands/data/lineage/command.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	kcmd "github.com/opst/knitfab/cmd/knit/commandline/command"
 	kenv "github.com/opst/knitfab/cmd/knit/env"
@@ -771,7 +772,7 @@ func TraceUpstreamForSingleNode(
 }
 
 func getData(ctx context.Context, client krst.KnitClient, knitId string) (apidata.Detail, error) {
-	datas, err := client.FindData(ctx, []apitag.Tag{knitIdTag(knitId)})
+	datas, err := client.FindData(ctx, []apitag.Tag{knitIdTag(knitId)}, time.Time{}, 0)
 	if err != nil {
 		return apidata.Detail{}, ErrFindDataWithKnitId(knitId, err)
 	}

--- a/cmd/knit/subcommands/data/lineage/command_test.go
+++ b/cmd/knit/subcommands/data/lineage/command_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	kcmd "github.com/opst/knitfab/cmd/knit/commandline/command"
 	kprof "github.com/opst/knitfab/cmd/knit/config/profiles"
@@ -263,7 +264,7 @@ func TestTraceDownStream(t *testing.T) {
 			// Store arguments and return values for each call
 			nthData := 0
 			mock.Impl.FindData = func(
-				ctx context.Context, tags []apitag.Tag,
+				ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration,
 			) ([]apidata.Detail, error) {
 				ret := when.FindDataReturns[nthData]
 				nthData += 1
@@ -796,7 +797,7 @@ func TestTraceDownStream(t *testing.T) {
 
 	t.Run("When FindData returns Empty array it returns ErrNotFoundData", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, nil
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -815,7 +816,7 @@ func TestTraceDownStream(t *testing.T) {
 	expectedError := errors.New("fake error")
 	t.Run("When FindData fails, it returns the error that contains that error ", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, expectedError
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -834,7 +835,7 @@ func TestTraceDownStream(t *testing.T) {
 	t.Run("When GetRun fails, it returns the error that contains that error", func(t *testing.T) {
 		mock := mock.New(t)
 		knitId := "knitId-test"
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{
 				dummyData(knitId, "run1", "run2"),
 			}, nil
@@ -872,7 +873,7 @@ func TestTraceUpStream(t *testing.T) {
 			// Store arguments and return values for each call
 			nthData := 0
 			mock.Impl.FindData = func(
-				ctx context.Context, tags []apitag.Tag) (
+				ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) (
 				[]apidata.Detail, error) {
 				ret := when.FindDataReturns[nthData]
 				nthData += 1
@@ -1274,7 +1275,7 @@ func TestTraceUpStream(t *testing.T) {
 
 	t.Run("When FindData returns Empty array it returns ErrNotFoundData", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, nil
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -1293,7 +1294,7 @@ func TestTraceUpStream(t *testing.T) {
 	expectedError := errors.New("fake error")
 	t.Run("When FindData fails, it returns the error that contains that error ", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, expectedError
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -1315,7 +1316,7 @@ func TestTraceUpStream(t *testing.T) {
 			return apirun.Detail{}, expectedError
 		}
 		knitId := "knitId-test"
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{
 				dummyData(knitId, "run0", "run2"),
 			}, nil

--- a/cmd/knit/subcommands/data/lineage/command_test.go
+++ b/cmd/knit/subcommands/data/lineage/command_test.go
@@ -264,7 +264,7 @@ func TestTraceDownStream(t *testing.T) {
 			// Store arguments and return values for each call
 			nthData := 0
 			mock.Impl.FindData = func(
-				ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration,
+				ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration,
 			) ([]apidata.Detail, error) {
 				ret := when.FindDataReturns[nthData]
 				nthData += 1
@@ -797,7 +797,7 @@ func TestTraceDownStream(t *testing.T) {
 
 	t.Run("When FindData returns Empty array it returns ErrNotFoundData", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, nil
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -816,7 +816,7 @@ func TestTraceDownStream(t *testing.T) {
 	expectedError := errors.New("fake error")
 	t.Run("When FindData fails, it returns the error that contains that error ", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, expectedError
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -835,7 +835,7 @@ func TestTraceDownStream(t *testing.T) {
 	t.Run("When GetRun fails, it returns the error that contains that error", func(t *testing.T) {
 		mock := mock.New(t)
 		knitId := "knitId-test"
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{
 				dummyData(knitId, "run1", "run2"),
 			}, nil
@@ -873,7 +873,7 @@ func TestTraceUpStream(t *testing.T) {
 			// Store arguments and return values for each call
 			nthData := 0
 			mock.Impl.FindData = func(
-				ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) (
+				ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) (
 				[]apidata.Detail, error) {
 				ret := when.FindDataReturns[nthData]
 				nthData += 1
@@ -1275,7 +1275,7 @@ func TestTraceUpStream(t *testing.T) {
 
 	t.Run("When FindData returns Empty array it returns ErrNotFoundData", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, nil
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -1294,7 +1294,7 @@ func TestTraceUpStream(t *testing.T) {
 	expectedError := errors.New("fake error")
 	t.Run("When FindData fails, it returns the error that contains that error ", func(t *testing.T) {
 		mock := mock.New(t)
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{}, expectedError
 		}
 		mock.Impl.GetRun = func(ctx context.Context, runId string) (apirun.Detail, error) {
@@ -1316,7 +1316,7 @@ func TestTraceUpStream(t *testing.T) {
 			return apirun.Detail{}, expectedError
 		}
 		knitId := "knitId-test"
-		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since time.Time, duration time.Duration) ([]apidata.Detail, error) {
+		mock.Impl.FindData = func(ctx context.Context, tags []apitag.Tag, since *time.Time, duration *time.Duration) ([]apidata.Detail, error) {
 			return []apidata.Detail{
 				dummyData(knitId, "run0", "run2"),
 			}, nil

--- a/cmd/knit/subcommands/run/find/command.go
+++ b/cmd/knit/subcommands/run/find/command.go
@@ -24,7 +24,7 @@ type Flag struct {
 	KnitIdOut *kflag.Argslice     `flag:"out-knitid,short=o,help=Find Run where the Output has this Knit Id. Repeatable."`
 	Status    *kflag.Argslice     `flag:"status,short=s,metavar=waiting|deactivated|starting|running|done|failed...,help=Find Run in this status. Repeatable."`
 	Since     *kflag.LooseRFC3339 `flag:"since,help=Find Run only updated at this time or later."`
-	Duration  time.Duration       `flag:"duration,help=Find Run only equal or earlier than '--since' + '--duration'."`
+	Duration  time.Duration       `flag:"duration,help=Find Run only updated at a time earlier than the sum of since and duration."`
 }
 
 type Command struct {
@@ -92,8 +92,8 @@ sub-seconds, seconds, minutes, and hours, in the description.
 If the time zone is omitted, the local time zone is applied. 
 When including a date and time, the following characters are allowed as delimiters between the date and time: "T" or space.
 
-Duration is a flag used in conjunction with Since. 
-It targets Runs for search that have been updated at equal to or earlier than 'Since + duration'.
+Duration is a flag used in conjunction with since. 
+It targets Runs for search that have been updated at a time earlier than the sum of since and duration.
 Duration can be described in Go's time.Duration type.
 Examples of duration are "300ms", "1.5h" or "2h45m". 
 `,

--- a/cmd/knit/subcommands/run/find/command.go
+++ b/cmd/knit/subcommands/run/find/command.go
@@ -32,12 +32,7 @@ type Command struct {
 		ctx context.Context,
 		log *log.Logger,
 		client krst.KnitClient,
-		planId []string,
-		knitIdIn []string,
-		knitIdOut []string,
-		status []string,
-		since time.Time,
-		duration time.Duration,
+		parameter krst.FindRunParameter,
 	) ([]apirun.Detail, error)
 }
 
@@ -46,12 +41,7 @@ func WithTask(
 		ctx context.Context,
 		log *log.Logger,
 		client krst.KnitClient,
-		planId []string,
-		knitIdIn []string,
-		knitIdOut []string,
-		status []string,
-		since time.Time,
-		duration time.Duration,
+		parameter krst.FindRunParameter,
 	) ([]apirun.Detail, error),
 ) func(*Command) *Command {
 	return func(dfc *Command) *Command {
@@ -98,7 +88,7 @@ If the same flags except 'since' and 'duration' are specified multiple times, it
 
 Since targets Runs that have been updated at equal to or later than since.
 The since can be described in RFC3339 date-time format, and it is also possible to omit 
-sub-seconds,seconds, minutes, and hours, in the description.
+sub-seconds, seconds, minutes, and hours, in the description.
 If the time zone is omitted, the local time zone is applied. 
 When including a date and time, the following characters are allowed as delimiters between the date and time: "T" or space.
 
@@ -145,7 +135,16 @@ func (cmd *Command) Execute(
 		return fmt.Errorf("%w: since and duration must be specified together", kcmd.ErrUsage)
 	}
 
-	run, err := cmd.task(ctx, l, c, planId, knitIdIn, knitIdOut, status, since, duration)
+	parameter := krst.FindRunParameter{
+		PlanId:    planId,
+		KnitIdIn:  knitIdIn,
+		KnitIdOut: knitIdOut,
+		Status:    status,
+		Since:     &since,
+		Duration:  &duration,
+	}
+
+	run, err := cmd.task(ctx, l, c, parameter)
 	if err != nil {
 		return err
 	}
@@ -162,15 +161,9 @@ func RunFindRun(
 	ctx context.Context,
 	logger *log.Logger,
 	client krst.KnitClient,
-	planId []string,
-	knitIdIn []string,
-	knitIdOut []string,
-	status []string,
-	since time.Time,
-	duration time.Duration,
+	parameter krst.FindRunParameter,
 ) ([]apirun.Detail, error) {
-
-	result, err := client.FindRun(ctx, planId, knitIdIn, knitIdOut, status, since, duration)
+	result, err := client.FindRun(ctx, parameter)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/knitd/handlers/data.go
+++ b/cmd/knitd/handlers/data.go
@@ -33,7 +33,7 @@ func GetDataForDataHandler(dbData kdb.DataInterface) echo.HandlerFunc {
 		since := c.QueryParam("since")
 		duration := c.QueryParam("duration")
 
-		knitIds, err := dbData.GetKnitIdByDataFindQuery(ctx, tags, since, duration)
+		knitIds, err := dbData.Find(ctx, tags, since, duration)
 		if err != nil {
 			return apierr.InternalServerError(err)
 		}

--- a/cmd/knitd/handlers/data.go
+++ b/cmd/knitd/handlers/data.go
@@ -30,7 +30,10 @@ func GetDataForDataHandler(dbData kdb.DataInterface) echo.HandlerFunc {
 			return apierr.InternalServerError(err)
 		}
 
-		knitIds, err := dbData.GetKnitIdByTags(ctx, tags)
+		since := c.QueryParam("since")
+		duration := c.QueryParam("duration")
+
+		knitIds, err := dbData.GetKnitIdByDataFindQuery(ctx, tags, since, duration)
 		if err != nil {
 			return apierr.InternalServerError(err)
 		}

--- a/cmd/knitd/handlers/data.go
+++ b/cmd/knitd/handlers/data.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	apidata "github.com/opst/knitfab/pkg/api/types/data"
 	apierr "github.com/opst/knitfab/pkg/api/types/errors"
 	apitags "github.com/opst/knitfab/pkg/api/types/tags"
 	kdb "github.com/opst/knitfab/pkg/db"
+	"github.com/opst/knitfab/pkg/utils/rfctime"
 )
 
 func GetDataForDataHandler(dbData kdb.DataInterface) echo.HandlerFunc {
@@ -30,10 +32,36 @@ func GetDataForDataHandler(dbData kdb.DataInterface) echo.HandlerFunc {
 			return apierr.InternalServerError(err)
 		}
 
-		since := c.QueryParam("since")
-		duration := c.QueryParam("duration")
+		paramSicne := c.QueryParam("since")
+		var since *time.Time
 
-		knitIds, err := dbData.Find(ctx, tags, since, duration)
+		if paramSicne != "" {
+			t, err := rfctime.ParseRFC3339DateTime(paramSicne)
+			if err != nil {
+				return apierr.BadRequest(
+					`"since" should be a RFC3339 date-time format`,
+					err,
+				)
+			}
+			_t := t.Time()
+			since = &_t
+		}
+
+		paramDuration := c.QueryParam("duration")
+		var until *time.Time
+		if paramDuration != "" {
+			d, err := time.ParseDuration(paramDuration)
+			if err != nil {
+				return apierr.BadRequest(
+					`"duration" should be a Go duration format`,
+					err,
+				)
+			}
+			_t := since.Add(d)
+			until = &_t
+		}
+
+		knitIds, err := dbData.Find(ctx, tags, since, until)
 		if err != nil {
 			return apierr.InternalServerError(err)
 		}

--- a/cmd/knitd/handlers/data_test.go
+++ b/cmd/knitd/handlers/data_test.go
@@ -29,7 +29,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 
 	t.Run("When data is received from the database, it should be converted to JSON format", func(t *testing.T) {
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.GetKnitIdByDataFindQuery = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
 			return []string{"knit-1", "knit-2"}, nil
 		}
 		mckdbdata.Impl.Get = func(ctx context.Context, knitId []string) (map[string]kdb.KnitData, error) {
@@ -167,7 +167,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 		expectedDuration := "2h30m45s"
 
 		if !cmp.SliceEqWith(
-			mckdbdata.Calls.GetKnitIdByDataFindQuery,
+			mckdbdata.Calls.Find,
 			[]struct {
 				Tags     []kdb.Tag
 				Since    string
@@ -190,7 +190,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 					a.Since == b.Since && a.Duration == b.Duration
 			},
 		) {
-			t.Error("DataInterface.GetKnitIdByTags did not call with correct userTag args.")
+			t.Error("DataInterface.Find did not call with correct userTag args.")
 		}
 
 		expected := []apidata.Detail{
@@ -307,7 +307,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 		knitId := []string{}
 
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.GetKnitIdByDataFindQuery = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
 			d := knitId
 			return d, nil
 		}
@@ -370,7 +370,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 
 	t.Run("When Process of obtaining knitId from specified tag encounters an internal error, status code should be 500", func(t *testing.T) {
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.GetKnitIdByDataFindQuery = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
 			return nil, errors.New("Test Internal Error")
 		}
 
@@ -393,7 +393,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 		knitId := []string{"knit-1"}
 
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.GetKnitIdByDataFindQuery = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
 			d := knitId
 			return d, nil
 		}

--- a/cmd/knitd/handlers/data_test.go
+++ b/cmd/knitd/handlers/data_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	httptestutil "github.com/opst/knitfab/internal/testutils/http"
@@ -29,7 +30,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 
 	t.Run("When data is received from the database, it should be converted to JSON format", func(t *testing.T) {
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since *time.Time, until *time.Time) ([]string, error) {
 			return []string{"knit-1", "knit-2"}, nil
 		}
 		mckdbdata.Impl.Get = func(ctx context.Context, knitId []string) (map[string]kdb.KnitData, error) {
@@ -163,31 +164,32 @@ func TestGetDataForDataHandler(t *testing.T) {
 			{Key: "knit#transient", Value: "processing"},
 		}
 
-		expectedSince := "2024-04-01T12:00:00+00:00"
-		expectedDuration := "2h30m45s"
+		expectedTime := "2024-04-01T12:00:00+00:00"
+		expectedSince := try.To(rfctime.ParseRFC3339DateTime(expectedTime)).OrFatal(t).Time()
+		expectedUntil := try.To(rfctime.ParseRFC3339DateTime(expectedTime)).OrFatal(t).Time().Add(2*time.Hour + 30*time.Minute + 45*time.Second)
 
 		if !cmp.SliceEqWith(
 			mckdbdata.Calls.Find,
 			[]struct {
-				Tags     []kdb.Tag
-				Since    string
-				Duration string
+				Tags  []kdb.Tag
+				Since *time.Time
+				Until *time.Time
 			}{
-				{Tags: expectTag, Since: expectedSince, Duration: expectedDuration},
+				{Tags: expectTag, Since: &expectedSince, Until: &expectedUntil},
 			},
 			func(
 				a struct {
-					Tags     []kdb.Tag
-					Since    string
-					Duration string
+					Tags  []kdb.Tag
+					Since *time.Time
+					Until *time.Time
 				},
 				b struct {
-					Tags     []kdb.Tag
-					Since    string
-					Duration string
+					Tags  []kdb.Tag
+					Since *time.Time
+					Until *time.Time
 				}) bool {
 				return cmp.SliceContentEqWith(utils.RefOf(a.Tags), utils.RefOf(b.Tags), (*kdb.Tag).Equal) &&
-					a.Since == b.Since && a.Duration == b.Duration
+					a.Since.Equal(*b.Since) && a.Until.Equal(*b.Until)
 			},
 		) {
 			t.Error("DataInterface.Find did not call with correct userTag args.")
@@ -307,7 +309,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 		knitId := []string{}
 
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since *time.Time, until *time.Time) ([]string, error) {
 			d := knitId
 			return d, nil
 		}
@@ -370,7 +372,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 
 	t.Run("When Process of obtaining knitId from specified tag encounters an internal error, status code should be 500", func(t *testing.T) {
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since *time.Time, until *time.Time) ([]string, error) {
 			return nil, errors.New("Test Internal Error")
 		}
 
@@ -393,7 +395,7 @@ func TestGetDataForDataHandler(t *testing.T) {
 		knitId := []string{"knit-1"}
 
 		mckdbdata := dbmock.NewDataInterface()
-		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+		mckdbdata.Impl.Find = func(ctx context.Context, tags []kdb.Tag, since *time.Time, until *time.Time) ([]string, error) {
 			d := knitId
 			return d, nil
 		}

--- a/cmd/knitd/handlers/run.go
+++ b/cmd/knitd/handlers/run.go
@@ -43,7 +43,10 @@ func FindRunHandler(dbRun kdb.RunInterface) echo.HandlerFunc {
 			if since != "" {
 				t, err := rfctime.ParseRFC3339DateTime(since)
 				if err != nil {
-					return kdb.RunFindQuery{}, err
+					return kdb.RunFindQuery{}, apierr.BadRequest(
+						`"since" should be a RFC3339 date-time format`,
+						err,
+					)
 				}
 				_t := t.Time()
 				result.UpdatedSince = &_t
@@ -53,7 +56,10 @@ func FindRunHandler(dbRun kdb.RunInterface) echo.HandlerFunc {
 			if duration != "" {
 				d, err := time.ParseDuration(duration)
 				if err != nil {
-					return kdb.RunFindQuery{}, err
+					return kdb.RunFindQuery{}, apierr.BadRequest(
+						`"duration" should be a Go duration format`,
+						err,
+					)
 				}
 				_t := result.UpdatedSince.Add(d)
 				result.UpdatedUntil = &_t

--- a/cmd/knitd/handlers/run.go
+++ b/cmd/knitd/handlers/run.go
@@ -15,13 +15,15 @@ func FindRunHandler(dbRun kdb.RunInterface) echo.HandlerFunc {
 
 	return func(c echo.Context) error {
 		c.Response().Header().Add("Content-Type", "application/json")
-
 		query, err := func(c echo.Context) (kdb.RunFindQuery, error) {
+
 			result := kdb.RunFindQuery{
 				PlanId:       kstrings.SplitIfNotEmpty(c.QueryParam("plan"), ","),
 				InputKnitId:  kstrings.SplitIfNotEmpty(c.QueryParam("knitIdInput"), ","),
 				OutputKnitId: kstrings.SplitIfNotEmpty(c.QueryParam("knitIdOutput"), ","),
 				Status:       []kdb.KnitRunStatus{},
+				Since:        nil,
+				Duration:     nil,
 			}
 
 			for _, p := range kstrings.SplitIfNotEmpty(c.QueryParam("status"), ",") {
@@ -33,6 +35,16 @@ func FindRunHandler(dbRun kdb.RunInterface) echo.HandlerFunc {
 					)
 				}
 				result.Status = append(result.Status, s)
+			}
+
+			since := c.QueryParam("since")
+			if since != "" {
+				result.Since = &since
+			}
+
+			duration := c.QueryParam("duration")
+			if duration != "" {
+				result.Duration = &duration
 			}
 
 			return result, nil

--- a/cmd/knitd/handlers/run_test.go
+++ b/cmd/knitd/handlers/run_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	handlers "github.com/opst/knitfab/cmd/knitd/handlers"
@@ -36,8 +37,12 @@ func TestRunFindHandler(t *testing.T) {
 			body  []apirun.Detail
 		}
 
-		dummySince := "2024-04-01T12:00:00+00:00"
-		dummyDuration := "2h30m45s"
+		dummyUpdatedSince := try.To(rfctime.ParseRFC3339DateTime(
+			"2024-04-01T12:00:00+00:00",
+		)).OrFatal(t).Time()
+		dummyUpdatedUntil := try.To(rfctime.ParseRFC3339DateTime(
+			"2024-04-01T12:00:00+00:00",
+		)).OrFatal(t).Time().Add(2*time.Hour + 30*time.Minute + 45*time.Second)
 
 		for name, testcase := range map[string]struct {
 			when
@@ -54,8 +59,8 @@ func TestRunFindHandler(t *testing.T) {
 						InputKnitId:  []string{"in1", "in2"},
 						OutputKnitId: []string{"out3", "out4"},
 						Status:       []kdb.KnitRunStatus{kdb.Waiting, kdb.Running, kdb.Done},
-						Since:        &dummySince,
-						Duration:     &dummyDuration,
+						UpdatedSince: &dummyUpdatedSince,
+						UpdatedUntil: &dummyUpdatedUntil,
 					},
 					body: []apirun.Detail{},
 				},
@@ -411,8 +416,8 @@ func TestRunFindHandler(t *testing.T) {
 				},
 				then{
 					query: kdb.RunFindQuery{
-						Status: []kdb.KnitRunStatus{},
-						Since:  &dummySince,
+						Status:       []kdb.KnitRunStatus{},
+						UpdatedSince: &dummyUpdatedSince,
 					},
 					body: []apirun.Detail{},
 				},
@@ -425,9 +430,9 @@ func TestRunFindHandler(t *testing.T) {
 				},
 				then{
 					query: kdb.RunFindQuery{
-						Status:   []kdb.KnitRunStatus{},
-						Since:    &dummySince,
-						Duration: &dummyDuration,
+						Status:       []kdb.KnitRunStatus{},
+						UpdatedSince: &dummyUpdatedSince,
+						UpdatedUntil: &dummyUpdatedUntil,
 					},
 					body: []apirun.Detail{},
 				},
@@ -442,8 +447,8 @@ func TestRunFindHandler(t *testing.T) {
 						InputKnitId:  []string{"in1", "in2"},
 						OutputKnitId: []string{"out3", "out4"},
 						Status:       []kdb.KnitRunStatus{kdb.Waiting, kdb.Running, kdb.Done},
-						Since:        &dummySince,
-						Duration:     &dummyDuration,
+						UpdatedSince: &dummyUpdatedSince,
+						UpdatedUntil: &dummyUpdatedUntil,
 					},
 					body: []apirun.Detail{},
 				},
@@ -458,8 +463,8 @@ func TestRunFindHandler(t *testing.T) {
 						PlanId:       []string{"plan-x", "plan-y"},
 						OutputKnitId: []string{"out3", "out4"},
 						Status:       []kdb.KnitRunStatus{kdb.Waiting, kdb.Running, kdb.Done},
-						Since:        &dummySince,
-						Duration:     &dummyDuration,
+						UpdatedSince: &dummyUpdatedSince,
+						UpdatedUntil: &dummyUpdatedUntil,
 					},
 					body: []apirun.Detail{},
 				},
@@ -471,11 +476,11 @@ func TestRunFindHandler(t *testing.T) {
 				},
 				then{
 					query: kdb.RunFindQuery{
-						PlanId:      []string{"plan-x", "plan-y"},
-						InputKnitId: []string{"in1", "in2"},
-						Status:      []kdb.KnitRunStatus{kdb.Waiting, kdb.Running, kdb.Done},
-						Since:       &dummySince,
-						Duration:    &dummyDuration,
+						PlanId:       []string{"plan-x", "plan-y"},
+						InputKnitId:  []string{"in1", "in2"},
+						Status:       []kdb.KnitRunStatus{kdb.Waiting, kdb.Running, kdb.Done},
+						UpdatedSince: &dummyUpdatedSince,
+						UpdatedUntil: &dummyUpdatedUntil,
 					},
 					body: []apirun.Detail{},
 				},
@@ -490,8 +495,8 @@ func TestRunFindHandler(t *testing.T) {
 						PlanId:       []string{"plan-x", "plan-y"},
 						InputKnitId:  []string{"in1", "in2"},
 						OutputKnitId: []string{"out3", "out4"},
-						Since:        &dummySince,
-						Duration:     &dummyDuration,
+						UpdatedSince: &dummyUpdatedSince,
+						UpdatedUntil: &dummyUpdatedUntil,
 					},
 					body: []apirun.Detail{},
 				},
@@ -522,7 +527,7 @@ func TestRunFindHandler(t *testing.T) {
 						InputKnitId:  []string{"in1", "in2"},
 						OutputKnitId: []string{"out3", "out4"},
 						Status:       []kdb.KnitRunStatus{kdb.Waiting, kdb.Running, kdb.Done},
-						Since:        &dummySince,
+						UpdatedSince: &dummyUpdatedSince,
 					},
 					body: []apirun.Detail{},
 				},

--- a/cmd/knitd/handlers/run_test.go
+++ b/cmd/knitd/handlers/run_test.go
@@ -37,7 +37,7 @@ func TestRunFindHandler(t *testing.T) {
 		}
 
 		dummySince := "2024-04-01T12:00:00+00:00"
-		dummyDuration := "1 hours"
+		dummyDuration := "2h30m45s"
 
 		for name, testcase := range map[string]struct {
 			when
@@ -45,7 +45,7 @@ func TestRunFindHandler(t *testing.T) {
 		}{
 			"as empty when no runs are found": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -420,7 +420,7 @@ func TestRunFindHandler(t *testing.T) {
 			// duration is assumed to be used in conjunction with since.
 			"when it is queried about since and duration": {
 				when{
-					request: "/api/runs?since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -434,7 +434,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except planId": {
 				when{
-					request: "/api/runs?knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?knitIdInput=in1,in2&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -450,7 +450,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except input knit id": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdOutput=out3,out4&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -466,7 +466,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except output knit id": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&status=waiting,running,done&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{
@@ -482,7 +482,7 @@ func TestRunFindHandler(t *testing.T) {
 			},
 			"when it is queried about all dimensions except status": {
 				when{
-					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=1+hours",
+					request: "/api/runs?plan=plan-x,plan-y&knitIdInput=in1,in2&knitIdOutput=out3,out4&since=2024-04-01T12%3A00%3A00%2B00%3A00&duration=2h30m45s",
 					Runs:    []kdb.Run{},
 				},
 				then{

--- a/pkg/commandline/flag/flag.go
+++ b/pkg/commandline/flag/flag.go
@@ -3,9 +3,11 @@ package flag
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	apitags "github.com/opst/knitfab/pkg/api/types/tags"
 	"github.com/opst/knitfab/pkg/utils"
+	"github.com/opst/knitfab/pkg/utils/rfctime"
 )
 
 type Argslice []string
@@ -40,5 +42,20 @@ func (t *Tags) Set(v string) error {
 		return err
 	}
 	*t = append(*t, tag)
+	return nil
+}
+
+type LooseRFC3339 time.Time
+
+func (t *LooseRFC3339) String() string {
+	return time.Time(*t).Format(rfctime.RFC3339DateTimeFormatZ)
+}
+
+func (t *LooseRFC3339) Set(v string) error {
+	parsedTime, err := rfctime.ParseLooseRFC3339(v)
+	if err != nil {
+		return err
+	}
+	*t = LooseRFC3339(parsedTime)
 	return nil
 }

--- a/pkg/db/data.go
+++ b/pkg/db/data.go
@@ -46,7 +46,7 @@ type DataInterface interface {
 	//
 	Get(context.Context, []string) (map[string]KnitData, error)
 
-	// Retrieve data that contains all specified tags and range of updated time.
+	// Retrieve KnitId of the data that contains all specified tags and range of updated time.
 	//
 	// args:
 	//     - ctx: context
@@ -58,7 +58,7 @@ type DataInterface interface {
 	//     - []string: Knitid of the data that meets the conditions
 	//     - error
 	//
-	GetKnitIdByDataFindQuery(context.Context, []Tag, string, string) ([]string, error)
+	Find(context.Context, []Tag, string, string) ([]string, error)
 
 	// update tags on data.
 	//

--- a/pkg/db/data.go
+++ b/pkg/db/data.go
@@ -46,17 +46,19 @@ type DataInterface interface {
 	//
 	Get(context.Context, []string) (map[string]KnitData, error)
 
-	// Retrieve data that contains all specified tags
+	// Retrieve data that contains all specified tags and range of updated time.
 	//
 	// args:
 	//     - ctx: context
 	//     - []Tag: specified tags
+	//     - string: start of the time range
+	//     - string: duration of the time range
 	//
 	// returns:
 	//     - []string: Knitid of the data that meets the conditions
 	//     - error
 	//
-	GetKnitIdByTags(context.Context, []Tag) ([]string, error)
+	GetKnitIdByDataFindQuery(context.Context, []Tag, string, string) ([]string, error)
 
 	// update tags on data.
 	//

--- a/pkg/db/data.go
+++ b/pkg/db/data.go
@@ -51,14 +51,14 @@ type DataInterface interface {
 	// args:
 	//     - ctx: context
 	//     - []Tag: specified tags
-	//     - string: start of the time range
-	//     - string: duration of the time range
+	//     - *Time: start of the time range
+	//     - *Time: end of the time range
 	//
 	// returns:
 	//     - []string: Knitid of the data that meets the conditions
 	//     - error
 	//
-	Find(context.Context, []Tag, string, string) ([]string, error)
+	Find(context.Context, []Tag, *time.Time, *time.Time) ([]string, error)
 
 	// update tags on data.
 	//

--- a/pkg/db/mocks/data.go
+++ b/pkg/db/mocks/data.go
@@ -10,17 +10,17 @@ import (
 
 type DataInterface struct {
 	Impl struct {
-		Get                      func(context.Context, []string) (map[string]kdb.KnitData, error)
-		GetKnitIdByDataFindQuery func(context.Context, []kdb.Tag, string, string) ([]string, error)
-		UpdateTag                func(context.Context, string, kdb.TagDelta) error
-		NewAgent                 func(context.Context, string, kdb.DataAgentMode, time.Duration) (kdb.DataAgent, error)
-		RemoveAgent              func(context.Context, string) error
-		PickAndRemoveAgent       func(context.Context, kdb.DataAgentCursor, func(kdb.DataAgent) (bool, error)) (kdb.DataAgentCursor, error)
-		GetAgentName             func(context.Context, string, []kdb.DataAgentMode) ([]string, error)
+		Get                func(context.Context, []string) (map[string]kdb.KnitData, error)
+		Find               func(context.Context, []kdb.Tag, string, string) ([]string, error)
+		UpdateTag          func(context.Context, string, kdb.TagDelta) error
+		NewAgent           func(context.Context, string, kdb.DataAgentMode, time.Duration) (kdb.DataAgent, error)
+		RemoveAgent        func(context.Context, string) error
+		PickAndRemoveAgent func(context.Context, kdb.DataAgentCursor, func(kdb.DataAgent) (bool, error)) (kdb.DataAgentCursor, error)
+		GetAgentName       func(context.Context, string, []kdb.DataAgentMode) ([]string, error)
 	}
 	Calls struct {
-		Get                      CallLog[struct{ KnitId []string }]
-		GetKnitIdByDataFindQuery CallLog[struct {
+		Get  CallLog[struct{ KnitId []string }]
+		Find CallLog[struct {
 			Tags     []kdb.Tag
 			Since    string
 			Duration string
@@ -59,16 +59,16 @@ func (di *DataInterface) Get(ctx context.Context, knitId []string) (map[string]k
 	panic(errors.New("it should no be called"))
 }
 
-func (di *DataInterface) GetKnitIdByDataFindQuery(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
-	di.Calls.GetKnitIdByDataFindQuery = append(di.Calls.GetKnitIdByDataFindQuery, struct {
+func (di *DataInterface) Find(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+	di.Calls.Find = append(di.Calls.Find, struct {
 		Tags     []kdb.Tag
 		Since    string
 		Duration string
 	}{
 		Tags: tags, Since: since, Duration: duration,
 	})
-	if di.Impl.GetKnitIdByDataFindQuery != nil {
-		return di.Impl.GetKnitIdByDataFindQuery(ctx, tags, since, duration)
+	if di.Impl.Find != nil {
+		return di.Impl.Find(ctx, tags, since, duration)
 	}
 	panic(errors.New("it should no be called"))
 }

--- a/pkg/db/mocks/data.go
+++ b/pkg/db/mocks/data.go
@@ -11,7 +11,7 @@ import (
 type DataInterface struct {
 	Impl struct {
 		Get                func(context.Context, []string) (map[string]kdb.KnitData, error)
-		Find               func(context.Context, []kdb.Tag, string, string) ([]string, error)
+		Find               func(context.Context, []kdb.Tag, *time.Time, *time.Time) ([]string, error)
 		UpdateTag          func(context.Context, string, kdb.TagDelta) error
 		NewAgent           func(context.Context, string, kdb.DataAgentMode, time.Duration) (kdb.DataAgent, error)
 		RemoveAgent        func(context.Context, string) error
@@ -21,9 +21,9 @@ type DataInterface struct {
 	Calls struct {
 		Get  CallLog[struct{ KnitId []string }]
 		Find CallLog[struct {
-			Tags     []kdb.Tag
-			Since    string
-			Duration string
+			Tags  []kdb.Tag
+			Since *time.Time
+			Until *time.Time
 		}]
 		Updatetag CallLog[struct {
 			KnitId string
@@ -59,16 +59,16 @@ func (di *DataInterface) Get(ctx context.Context, knitId []string) (map[string]k
 	panic(errors.New("it should no be called"))
 }
 
-func (di *DataInterface) Find(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+func (di *DataInterface) Find(ctx context.Context, tags []kdb.Tag, since *time.Time, until *time.Time) ([]string, error) {
 	di.Calls.Find = append(di.Calls.Find, struct {
-		Tags     []kdb.Tag
-		Since    string
-		Duration string
+		Tags  []kdb.Tag
+		Since *time.Time
+		Until *time.Time
 	}{
-		Tags: tags, Since: since, Duration: duration,
+		Tags: tags, Since: since, Until: until,
 	})
 	if di.Impl.Find != nil {
-		return di.Impl.Find(ctx, tags, since, duration)
+		return di.Impl.Find(ctx, tags, since, until)
 	}
 	panic(errors.New("it should no be called"))
 }

--- a/pkg/db/mocks/data.go
+++ b/pkg/db/mocks/data.go
@@ -10,18 +10,22 @@ import (
 
 type DataInterface struct {
 	Impl struct {
-		Get                func(context.Context, []string) (map[string]kdb.KnitData, error)
-		GetKnitIdByTags    func(context.Context, []kdb.Tag) ([]string, error)
-		UpdateTag          func(context.Context, string, kdb.TagDelta) error
-		NewAgent           func(context.Context, string, kdb.DataAgentMode, time.Duration) (kdb.DataAgent, error)
-		RemoveAgent        func(context.Context, string) error
-		PickAndRemoveAgent func(context.Context, kdb.DataAgentCursor, func(kdb.DataAgent) (bool, error)) (kdb.DataAgentCursor, error)
-		GetAgentName       func(context.Context, string, []kdb.DataAgentMode) ([]string, error)
+		Get                      func(context.Context, []string) (map[string]kdb.KnitData, error)
+		GetKnitIdByDataFindQuery func(context.Context, []kdb.Tag, string, string) ([]string, error)
+		UpdateTag                func(context.Context, string, kdb.TagDelta) error
+		NewAgent                 func(context.Context, string, kdb.DataAgentMode, time.Duration) (kdb.DataAgent, error)
+		RemoveAgent              func(context.Context, string) error
+		PickAndRemoveAgent       func(context.Context, kdb.DataAgentCursor, func(kdb.DataAgent) (bool, error)) (kdb.DataAgentCursor, error)
+		GetAgentName             func(context.Context, string, []kdb.DataAgentMode) ([]string, error)
 	}
 	Calls struct {
-		Get             CallLog[struct{ KnitId []string }]
-		GetKnitIdByTags CallLog[struct{ Tags []kdb.Tag }]
-		Updatetag       CallLog[struct {
+		Get                      CallLog[struct{ KnitId []string }]
+		GetKnitIdByDataFindQuery CallLog[struct {
+			Tags     []kdb.Tag
+			Since    string
+			Duration string
+		}]
+		Updatetag CallLog[struct {
 			KnitId string
 			Delta  kdb.TagDelta
 		}]
@@ -55,10 +59,16 @@ func (di *DataInterface) Get(ctx context.Context, knitId []string) (map[string]k
 	panic(errors.New("it should no be called"))
 }
 
-func (di *DataInterface) GetKnitIdByTags(ctx context.Context, tags []kdb.Tag) ([]string, error) {
-	di.Calls.GetKnitIdByTags = append(di.Calls.GetKnitIdByTags, struct{ Tags []kdb.Tag }{Tags: tags})
-	if di.Impl.GetKnitIdByTags != nil {
-		return di.Impl.GetKnitIdByTags(ctx, tags)
+func (di *DataInterface) GetKnitIdByDataFindQuery(ctx context.Context, tags []kdb.Tag, since string, duration string) ([]string, error) {
+	di.Calls.GetKnitIdByDataFindQuery = append(di.Calls.GetKnitIdByDataFindQuery, struct {
+		Tags     []kdb.Tag
+		Since    string
+		Duration string
+	}{
+		Tags: tags, Since: since, Duration: duration,
+	})
+	if di.Impl.GetKnitIdByDataFindQuery != nil {
+		return di.Impl.GetKnitIdByDataFindQuery(ctx, tags, since, duration)
 	}
 	panic(errors.New("it should no be called"))
 }

--- a/pkg/db/postgres/data/data_test.go
+++ b/pkg/db/postgres/data/data_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/opst/knitfab/pkg/utils/try"
 )
 
-func TestData_GetKnitIdByDataFindQuery(t *testing.T) {
+func TestData_Find(t *testing.T) {
 	poolBroaker := testenv.NewPoolBroaker(context.Background(), t)
 
 	type when struct {
@@ -698,7 +698,7 @@ func TestData_GetKnitIdByDataFindQuery(t *testing.T) {
 				}
 				testee := kpgdata.New(pool, kpgdata.WithNominator(nom))
 
-				actual := try.To(testee.GetKnitIdByDataFindQuery(ctx, testcase.when.tags, testcase.since, testcase.duration)).OrFatal(t)
+				actual := try.To(testee.Find(ctx, testcase.when.tags, testcase.since, testcase.duration)).OrFatal(t)
 
 				if !cmp.SliceEq(actual, testcase.then.knitId) {
 					t.Errorf(
@@ -779,7 +779,7 @@ func TestData_GetKnitIdByDataFindQuery(t *testing.T) {
 			}
 			testee := kpgdata.New(pool, kpgdata.WithNominator(nom))
 
-			actual := try.To(testee.GetKnitIdByDataFindQuery(
+			actual := try.To(testee.Find(
 				ctx,
 				[]kdb.Tag{
 					{Key: kdb.KeyKnitTransient, Value: kdb.ValueKnitTransientProcessing},
@@ -805,7 +805,7 @@ func TestData_GetKnitIdByDataFindQuery(t *testing.T) {
 			}
 			testee := kpgdata.New(pool, kpgdata.WithNominator(nom))
 
-			actual := try.To(testee.GetKnitIdByDataFindQuery(
+			actual := try.To(testee.Find(
 				ctx,
 				[]kdb.Tag{
 					{Key: kdb.KeyKnitTransient, Value: kdb.ValueKnitTransientFailed},
@@ -831,7 +831,7 @@ func TestData_GetKnitIdByDataFindQuery(t *testing.T) {
 			}
 			testee := kpgdata.New(pool, kpgdata.WithNominator(nom))
 
-			actual := try.To(testee.GetKnitIdByDataFindQuery(
+			actual := try.To(testee.Find(
 				ctx,
 				[]kdb.Tag{
 					kdb.NewTimestampTag(oldTimestamp),
@@ -906,7 +906,7 @@ func TestData_GetKnitIdByDataFindQuery(t *testing.T) {
 			}
 			testee := kpgdata.New(pool, kpgdata.WithNominator(nom))
 
-			actual := try.To(testee.GetKnitIdByDataFindQuery(
+			actual := try.To(testee.Find(
 				ctx,
 				[]kdb.Tag{
 					{Key: kdb.KeyKnitTransient, Value: kdb.ValueKnitTransientProcessing},
@@ -930,7 +930,7 @@ func TestData_GetKnitIdByDataFindQuery(t *testing.T) {
 			}
 			testee := kpgdata.New(pool, kpgdata.WithNominator(nom))
 
-			actual := try.To(testee.GetKnitIdByDataFindQuery(
+			actual := try.To(testee.Find(
 				ctx,
 				[]kdb.Tag{
 					{Key: kdb.KeyKnitTransient, Value: kdb.ValueKnitTransientFailed},

--- a/pkg/db/postgres/run/run.go
+++ b/pkg/db/postgres/run/run.go
@@ -527,16 +527,7 @@ func (m *runPG) Finish(ctx context.Context, runId string) error {
 	return nil
 }
 
-func (m *runPG) find(
-	ctx context.Context, conn kpool.Conn,
-	query kdb.RunFindQuery,
-	// planId []string,
-	// knitIdIn []string,
-	// knitIdOut []string,
-	// status []kdb.KnitRunStatus,
-	// updatedSince *time.Time,
-	// updatedUntil *time.Time,
-) ([]string, error) {
+func (m *runPG) find(ctx context.Context, conn kpool.Conn, query kdb.RunFindQuery) ([]string, error) {
 
 	runIds := []string{}
 
@@ -565,7 +556,7 @@ func (m *runPG) find(
 		from "assign_and_data"
 		where 
 			($9::timestamp with time zone is null or "updated_at" >= $9::timestamp with time zone)
-			and ($10::timestamp with time zone is null or "updated_at" <= $10::timestamp with time zone)
+			and ($10::timestamp with time zone is null or "updated_at" < $10::timestamp with time zone)
 		order by "updated_at", "run_id"
 		`,
 		len(query.PlanId) == 0, query.PlanId,

--- a/pkg/db/postgres/run/tests/find_test.go
+++ b/pkg/db/postgres/run/tests/find_test.go
@@ -1128,7 +1128,7 @@ func TestRun_Find(t *testing.T) {
 }
 
 // Test to search using the new fields, "Since" and "Duration", added to RunFindQuery
-func TestRun_Find_Add(t *testing.T) {
+func TestRun_Find_Since_and_Duration(t *testing.T) {
 	poolBroaker := testenv.NewPoolBroaker(context.Background(), t)
 	type then struct {
 		run []string

--- a/pkg/db/postgres/run/tests/find_test.go
+++ b/pkg/db/postgres/run/tests/find_test.go
@@ -1138,14 +1138,17 @@ func TestRun_Find_Add(t *testing.T) {
 		then
 	}
 
-	basedTime := "2023-04-01T13:34:45+00:00"
-	baseUpdatedAT := try.To(rfctime.ParseRFC3339DateTime(
-		basedTime,
+	dummyUpdatedSince := try.To(rfctime.ParseRFC3339DateTime(
+		"2023-04-01T13:34:45+00:00",
 	)).OrFatal(t).Time()
 
 	//  time.Duration type.
-	dummyDuration1 := "30s"
-	dummyDuration2 := "2h10m"
+	dummyUpdatedUntil_1 := try.To(rfctime.ParseRFC3339DateTime(
+		"2023-04-01T13:34:45+00:00",
+	)).OrFatal(t).Time().Add(30 * time.Minute)
+	dummyUpdatedUntil_2 := try.To(rfctime.ParseRFC3339DateTime(
+		"2023-04-01T13:34:45+00:00",
+	)).OrFatal(t).Time().Add(2*time.Hour + 10*time.Minute)
 
 	given := tables.Operation{
 		Plan: []tables.Plan{
@@ -1169,7 +1172,7 @@ func TestRun_Find_Add(t *testing.T) {
 					RunId:     th.Padding36("plan-1-pseudo/-1hour"),
 					PlanId:    th.Padding36("plan-1-pseudo"),
 					Status:    kdb.Done,
-					UpdatedAt: baseUpdatedAT.Add(-1 * time.Hour),
+					UpdatedAt: dummyUpdatedSince.Add(-1 * time.Hour),
 				},
 				Outcomes: map[tables.Data]tables.DataAttibutes{
 					{
@@ -1186,7 +1189,7 @@ func TestRun_Find_Add(t *testing.T) {
 					RunId:     th.Padding36("plan-1-pseudo/basedtime"),
 					PlanId:    th.Padding36("plan-1-pseudo"),
 					Status:    kdb.Done,
-					UpdatedAt: baseUpdatedAT,
+					UpdatedAt: dummyUpdatedSince,
 				},
 				Outcomes: map[tables.Data]tables.DataAttibutes{
 					{
@@ -1204,7 +1207,7 @@ func TestRun_Find_Add(t *testing.T) {
 					RunId:     th.Padding36("plan-1-pseudo/30s"),
 					PlanId:    th.Padding36("plan-1-pseudo"),
 					Status:    kdb.Failed,
-					UpdatedAt: baseUpdatedAT.Add(30 * time.Second),
+					UpdatedAt: dummyUpdatedSince.Add(30 * time.Second),
 				},
 				Outcomes: map[tables.Data]tables.DataAttibutes{
 					{
@@ -1222,7 +1225,7 @@ func TestRun_Find_Add(t *testing.T) {
 					RunId:     th.Padding36("plan-1-pseudo/1minute/1hour"),
 					PlanId:    th.Padding36("plan-1-pseudo"),
 					Status:    kdb.Failed,
-					UpdatedAt: baseUpdatedAT.Add(1*time.Minute + 1*time.Hour),
+					UpdatedAt: dummyUpdatedSince.Add(1*time.Minute + 1*time.Hour),
 				},
 				Outcomes: map[tables.Data]tables.DataAttibutes{
 					{
@@ -1240,8 +1243,8 @@ func TestRun_Find_Add(t *testing.T) {
 	for name, data := range map[string]testcase{
 		"when no querying, it should find all runIds": {
 			when: kdb.RunFindQuery{
-				Since:    nil,
-				Duration: nil,
+				UpdatedSince: nil,
+				UpdatedUntil: nil,
 			},
 			then: then{
 				run: []string{
@@ -1254,8 +1257,8 @@ func TestRun_Find_Add(t *testing.T) {
 		},
 		"when querying by UpdatedAt, it should find runIds matching with the query": {
 			when: kdb.RunFindQuery{
-				Since:    &basedTime,
-				Duration: nil,
+				UpdatedSince: &dummyUpdatedSince,
+				UpdatedUntil: nil,
 			},
 			then: then{
 				run: []string{
@@ -1268,8 +1271,8 @@ func TestRun_Find_Add(t *testing.T) {
 		},
 		"when querying by UpdatedAt and Duration specified minutes, it should find runIds matching with the query": {
 			when: kdb.RunFindQuery{
-				Since:    &basedTime,
-				Duration: &dummyDuration1,
+				UpdatedSince: &dummyUpdatedSince,
+				UpdatedUntil: &dummyUpdatedUntil_1,
 			},
 			then: then{
 				run: []string{
@@ -1281,8 +1284,8 @@ func TestRun_Find_Add(t *testing.T) {
 
 		"when querying by UpdatedAt and Duration specified days and weeks, it should find runIds matching with the query": {
 			when: kdb.RunFindQuery{
-				Since:    &basedTime,
-				Duration: &dummyDuration2,
+				UpdatedSince: &dummyUpdatedSince,
+				UpdatedUntil: &dummyUpdatedUntil_2,
 			},
 			then: then{
 				run: []string{

--- a/pkg/db/run.go
+++ b/pkg/db/run.go
@@ -403,13 +403,23 @@ type RunFindQuery struct {
 	//
 	// If it is nil or empty, it means "match any".
 	Status []KnitRunStatus
+
+	// match if run's updated time is equal or later than Since.
+	Since *string
+
+	// match if run's updated time is equal or earlier than UpdatedAt + Duration.
+	Duration *string
 }
 
 func (rfq RunFindQuery) Equal(other RunFindQuery) bool {
 	return cmp.SliceContentEq(rfq.PlanId, other.PlanId) &&
 		cmp.SliceContentEq(rfq.InputKnitId, other.InputKnitId) &&
 		cmp.SliceContentEq(rfq.OutputKnitId, other.OutputKnitId) &&
-		cmp.SliceContentEq(rfq.Status, other.Status)
+		cmp.SliceContentEq(rfq.Status, other.Status) &&
+		((rfq.Since == nil && other.Since == nil) ||
+			(rfq.Since != nil && other.Since != nil && *rfq.Since == *other.Since)) &&
+		((rfq.Duration == nil && other.Duration == nil) ||
+			(rfq.Duration != nil && other.Duration != nil && *rfq.Duration == *other.Duration))
 }
 
 // relation between run and data; "How does the run uses data?"

--- a/pkg/db/run.go
+++ b/pkg/db/run.go
@@ -404,11 +404,11 @@ type RunFindQuery struct {
 	// If it is nil or empty, it means "match any".
 	Status []KnitRunStatus
 
-	// match if run's updated time is equal or later than Since.
-	Since *string
+	// match if run's updated time is equal or later than this UpdatedSince.
+	UpdatedSince *time.Time
 
-	// match if run's updated time is equal or earlier than UpdatedAt + Duration.
-	Duration *string
+	// match if run's updated time is equal or earlier than this UpdatedUntil.
+	UpdatedUntil *time.Time
 }
 
 func (rfq RunFindQuery) Equal(other RunFindQuery) bool {
@@ -416,10 +416,10 @@ func (rfq RunFindQuery) Equal(other RunFindQuery) bool {
 		cmp.SliceContentEq(rfq.InputKnitId, other.InputKnitId) &&
 		cmp.SliceContentEq(rfq.OutputKnitId, other.OutputKnitId) &&
 		cmp.SliceContentEq(rfq.Status, other.Status) &&
-		((rfq.Since == nil && other.Since == nil) ||
-			(rfq.Since != nil && other.Since != nil && *rfq.Since == *other.Since)) &&
-		((rfq.Duration == nil && other.Duration == nil) ||
-			(rfq.Duration != nil && other.Duration != nil && *rfq.Duration == *other.Duration))
+		((rfq.UpdatedSince == nil && other.UpdatedSince == nil) ||
+			(rfq.UpdatedSince != nil && other.UpdatedSince != nil && *rfq.UpdatedSince == *other.UpdatedSince)) &&
+		((rfq.UpdatedUntil == nil && other.UpdatedUntil == nil) ||
+			(rfq.UpdatedUntil != nil && other.UpdatedUntil != nil && *rfq.UpdatedUntil == *other.UpdatedUntil))
 }
 
 // relation between run and data; "How does the run uses data?"

--- a/pkg/db/run.go
+++ b/pkg/db/run.go
@@ -407,7 +407,7 @@ type RunFindQuery struct {
 	// match if run's updated time is equal or later than this UpdatedSince.
 	UpdatedSince *time.Time
 
-	// match if run's updated time is equal or earlier than this UpdatedUntil.
+	// match if run's updated time is earlier than this UpdatedUntil.
 	UpdatedUntil *time.Time
 }
 
@@ -417,9 +417,9 @@ func (rfq RunFindQuery) Equal(other RunFindQuery) bool {
 		cmp.SliceContentEq(rfq.OutputKnitId, other.OutputKnitId) &&
 		cmp.SliceContentEq(rfq.Status, other.Status) &&
 		((rfq.UpdatedSince == nil && other.UpdatedSince == nil) ||
-			(rfq.UpdatedSince != nil && other.UpdatedSince != nil && *rfq.UpdatedSince == *other.UpdatedSince)) &&
+			(rfq.UpdatedSince != nil && other.UpdatedSince != nil && rfq.UpdatedSince.Equal(*other.UpdatedSince))) &&
 		((rfq.UpdatedUntil == nil && other.UpdatedUntil == nil) ||
-			(rfq.UpdatedUntil != nil && other.UpdatedUntil != nil && *rfq.UpdatedUntil == *other.UpdatedUntil))
+			(rfq.UpdatedUntil != nil && other.UpdatedUntil != nil && rfq.UpdatedUntil.Equal(*other.UpdatedUntil)))
 }
 
 // relation between run and data; "How does the run uses data?"

--- a/pkg/utils/rfctime/rfc3339.go
+++ b/pkg/utils/rfctime/rfc3339.go
@@ -73,6 +73,15 @@ func (t RFC3339) String() string {
 	return time.Time(t).Format(RFC3339DateTimeFormat)
 }
 
+// When you need to get string with local timezone, use
+func (t RFC3339) StringWithLocalTimeZone() (string, error) {
+	location, err := time.LoadLocation("Local")
+	if err != nil {
+		return "", err
+	}
+	return time.Time(t).In(location).Format(RFC3339DateTimeFormat), nil
+}
+
 // Parse string to ISO8601 time.
 //
 // It trancates resolution to milli second.
@@ -82,6 +91,19 @@ func ParseRFC3339DateTime(s string) (RFC3339, error) {
 		return *new(RFC3339), err
 	}
 	return RFC3339(t), nil
+}
+
+// when you need to parse multiple formats, use
+func ParseMultipleFormats(s string, formats ...string) (RFC3339, string, error) {
+	var err error
+	var t time.Time
+	for _, format := range formats {
+		t, err = time.Parse(format, s)
+		if err == nil {
+			return RFC3339(t), format, nil
+		}
+	}
+	return *new(RFC3339), "", fmt.Errorf("failed to parse %s", s)
 }
 
 // implement encoding/json.Marshaller

--- a/pkg/utils/rfctime/rfc3339.go
+++ b/pkg/utils/rfctime/rfc3339.go
@@ -21,23 +21,23 @@ const RFC3339DateTimeFormatZ string = time.RFC3339Nano
 // The following format is used to parse the abbreviated form of RFC3339 date-time.
 const (
 	RFC3339DateNano       = "2006-01-02T15:04:05.999999999"
-	RFC3339DateNanoNoDeL  = "2006-01-02 15:04:05.999999999"
-	RFC3339DateNanoZNoDeL = "2006-01-02 15:04:05.999999999Z07:00"
+	RFC3339DateNanoSpace  = "2006-01-02 15:04:05.999999999"
+	RFC3339DateNanoZSpace = "2006-01-02 15:04:05.999999999Z07:00"
 
 	RFC3339DateSec       = "2006-01-02T15:04:05"
 	RFC3339DateSecZ      = "2006-01-02T15:04:05Z07:00"
-	RFC3339DateSecNoDeL  = "2006-01-02 15:04:05"
-	RFC3339DateSecZNoDeL = "2006-01-02 15:04:05Z07:00"
+	RFC3339DateSecSpace  = "2006-01-02 15:04:05"
+	RFC3339DateSecZSpace = "2006-01-02 15:04:05Z07:00"
 
 	RFC3339DateMin       = "2006-01-02T15:04"
 	RFC3339DateMinZ      = "2006-01-02T15:04Z07:00"
-	RFC3339DateMinNoDeL  = "2006-01-02 15:04"
-	RFC3339DateMinZNoDeL = "2006-01-02 15:04Z07:00"
+	RFC3339DateMinSpace  = "2006-01-02 15:04"
+	RFC3339DateMinZSpace = "2006-01-02 15:04Z07:00"
 
 	RFC3339DateHour       = "2006-01-02T15"
 	RFC3339DateHourZ      = "2006-01-02T15Z07:00"
-	RFC3339DateHourNoDeL  = "2006-01-02 15"
-	RFC3339DateHourZNoDeL = "2006-01-02 15Z07:00"
+	RFC3339DateHourSpace  = "2006-01-02 15"
+	RFC3339DateHourZSpace = "2006-01-02 15Z07:00"
 
 	RFC3339DateOnly  = "2006-01-02"
 	RFC3339DateOnlyZ = "2006-01-02Z07:00"
@@ -98,15 +98,6 @@ func (t RFC3339) String() string {
 	return time.Time(t).Format(RFC3339DateTimeFormat)
 }
 
-// When you need to get string with local timezone, use
-func (t RFC3339) StringWithLocalTimeZone() (string, error) {
-	location, err := time.LoadLocation("Local")
-	if err != nil {
-		return "", err
-	}
-	return time.Time(t).In(location).Format(RFC3339DateTimeFormat), nil
-}
-
 // Parse string to ISO8601 time.
 //
 // It trancates resolution to milli second.
@@ -120,17 +111,11 @@ func ParseRFC3339DateTime(s string) (RFC3339, error) {
 
 // When you need to parse string with the abbreviated forms of RFC3339 date-time, use this function.
 func ParseLooseRFC3339(s string) (RFC3339, error) {
-	// get local timezone
-	location, err := time.LoadLocation("Local")
-	if err != nil {
-		return RFC3339{}, err
-	}
-
 	formats := []string{
-		RFC3339DateTimeFormatZ, RFC3339DateNanoZNoDeL,
-		RFC3339DateSecZ, RFC3339DateSecZNoDeL,
-		RFC3339DateMinZ, RFC3339DateMinZNoDeL,
-		RFC3339DateHourZ, RFC3339DateHourZNoDeL,
+		RFC3339DateTimeFormatZ, RFC3339DateNanoZSpace,
+		RFC3339DateSecZ, RFC3339DateSecZSpace,
+		RFC3339DateMinZ, RFC3339DateMinZSpace,
+		RFC3339DateHourZ, RFC3339DateHourZSpace,
 		RFC3339DateOnlyZ,
 	}
 
@@ -141,11 +126,17 @@ func ParseLooseRFC3339(s string) (RFC3339, error) {
 		}
 	}
 
+	// get local timezone
+	location, err := time.LoadLocation("Local")
+	if err != nil {
+		return RFC3339{}, err
+	}
+
 	formatsWithoutTimeZone := []string{
-		RFC3339DateNano, RFC3339DateNanoNoDeL,
-		RFC3339DateSec, RFC3339DateSecNoDeL,
-		RFC3339DateMin, RFC3339DateMinNoDeL,
-		RFC3339DateHour, RFC3339DateHourNoDeL,
+		RFC3339DateNano, RFC3339DateNanoSpace,
+		RFC3339DateSec, RFC3339DateSecSpace,
+		RFC3339DateMin, RFC3339DateMinSpace,
+		RFC3339DateHour, RFC3339DateHourSpace,
 		RFC3339DateOnly,
 	}
 

--- a/pkg/utils/rfctime/rfc3339.go
+++ b/pkg/utils/rfctime/rfc3339.go
@@ -18,6 +18,31 @@ const RFC3339DateTimeFormat string = "2006-01-02T15:04:05.999-07:00"
 // Use it to parse RFC3339 date-time expression.
 const RFC3339DateTimeFormatZ string = time.RFC3339Nano
 
+// The following format is used to parse the abbreviated form of RFC3339 date-time.
+const (
+	RFC3339DateNano       = "2006-01-02T15:04:05.999999999"
+	RFC3339DateNanoNoDeL  = "2006-01-02 15:04:05.999999999"
+	RFC3339DateNanoZNoDeL = "2006-01-02 15:04:05.999999999Z07:00"
+
+	RFC3339DateSec       = "2006-01-02T15:04:05"
+	RFC3339DateSecZ      = "2006-01-02T15:04:05Z07:00"
+	RFC3339DateSecNoDeL  = "2006-01-02 15:04:05"
+	RFC3339DateSecZNoDeL = "2006-01-02 15:04:05Z07:00"
+
+	RFC3339DateMin       = "2006-01-02T15:04"
+	RFC3339DateMinZ      = "2006-01-02T15:04Z07:00"
+	RFC3339DateMinNoDeL  = "2006-01-02 15:04"
+	RFC3339DateMinZNoDeL = "2006-01-02 15:04Z07:00"
+
+	RFC3339DateHour       = "2006-01-02T15"
+	RFC3339DateHourZ      = "2006-01-02T15Z07:00"
+	RFC3339DateHourNoDeL  = "2006-01-02 15"
+	RFC3339DateHourZNoDeL = "2006-01-02 15Z07:00"
+
+	RFC3339DateOnly  = "2006-01-02"
+	RFC3339DateOnlyZ = "2006-01-02Z07:00"
+)
+
 // date-time in https://www.ietf.org/rfc/rfc3339.txt .
 // this is known as a subset of ISO8601 extended format.
 //
@@ -93,17 +118,45 @@ func ParseRFC3339DateTime(s string) (RFC3339, error) {
 	return RFC3339(t), nil
 }
 
-// when you need to parse multiple formats, use
-func ParseMultipleFormats(s string, formats ...string) (RFC3339, string, error) {
-	var err error
-	var t time.Time
+// When you need to parse string with the abbreviated forms of RFC3339 date-time, use this function.
+func ParseLooseRFC3339(s string) (RFC3339, error) {
+	// get local timezone
+	location, err := time.LoadLocation("Local")
+	if err != nil {
+		return RFC3339{}, err
+	}
+
+	formats := []string{
+		RFC3339DateTimeFormatZ, RFC3339DateNanoZNoDeL,
+		RFC3339DateSecZ, RFC3339DateSecZNoDeL,
+		RFC3339DateMinZ, RFC3339DateMinZNoDeL,
+		RFC3339DateHourZ, RFC3339DateHourZNoDeL,
+		RFC3339DateOnlyZ,
+	}
+
 	for _, format := range formats {
-		t, err = time.Parse(format, s)
+		t, err := time.Parse(format, s)
 		if err == nil {
-			return RFC3339(t), format, nil
+			return RFC3339(t), nil
 		}
 	}
-	return *new(RFC3339), "", fmt.Errorf("failed to parse %s", s)
+
+	formatsWithoutTimeZone := []string{
+		RFC3339DateNano, RFC3339DateNanoNoDeL,
+		RFC3339DateSec, RFC3339DateSecNoDeL,
+		RFC3339DateMin, RFC3339DateMinNoDeL,
+		RFC3339DateHour, RFC3339DateHourNoDeL,
+		RFC3339DateOnly,
+	}
+
+	for _, format := range formatsWithoutTimeZone {
+		t, err := time.ParseInLocation(format, s, location)
+		if err == nil {
+			return RFC3339(t), nil
+		}
+	}
+
+	return RFC3339{}, fmt.Errorf("failed to parse %s", s)
 }
 
 // implement encoding/json.Marshaller

--- a/pkg/utils/rfctime/rfc3339_test.go
+++ b/pkg/utils/rfctime/rfc3339_test.go
@@ -115,3 +115,179 @@ func Test_StringWithLocalTimeZone(t *testing.T) {
 		}
 	})
 }
+
+func Test_ParseLooseRFC3339(t *testing.T) {
+	type when struct {
+		args []string
+	}
+	type then struct {
+		expected []time.Time
+	}
+
+	theory := func(when when, then then) func(*testing.T) {
+		return func(t *testing.T) {
+			for i, w := range when.args {
+				testee, err := rfctime.ParseLooseRFC3339(w)
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectdRFC3339 := rfctime.RFC3339(then.expected[i])
+
+				if !testee.Time().Equal(then.expected[i]) {
+					t.Errorf("unmatch: as time: (actual, expected) = (%+v, %+v)", testee, then.expected[i])
+				}
+
+				if !testee.Equiv(expectdRFC3339) {
+					t.Errorf("unmatch: as RFC3339: (actual, expected) = (%+v, %+v)", testee, expectdRFC3339)
+				}
+			}
+		}
+	}
+
+	t.Run("it should parse when passed RFC3339DateNano format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12:34:56.987654321+07:00",
+				"2024-04-22 12:34:56.987654321+07:00",
+				"2024-04-22T12:34:56.987654321",
+				"2024-04-22 12:34:56.987654321",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 987654321,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	//
+	t.Run("it should parse when passed RFC3339DateSec format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12:34:56+07:00",
+				"2024-04-22 12:34:56+07:00",
+				"2024-04-22T12:34:56",
+				"2024-04-22 12:34:56",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 56, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	t.Run("it should parse when passed RFC3339DateMin format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12:34+07:00",
+				"2024-04-22 12:34+07:00",
+				"2024-04-22T12:34",
+				"2024-04-22 12:34",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 34, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	t.Run("it should parse when passed RFC3339DateHour format", theory(
+		when{
+			args: []string{
+				"2024-04-22T12+07:00",
+				"2024-04-22 12+07:00",
+				"2024-04-22T12",
+				"2024-04-22 12",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 12, 00, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+	t.Run("it should parse when passed RFC3339DateOnly format", theory(
+		when{
+			args: []string{
+				"2024-04-22+07:00",
+				"2024-04-22",
+			},
+		},
+		then{
+			expected: []time.Time{
+				time.Date(
+					2024, 4, 22, 00, 00, 00, 000000000,
+					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
+				),
+				time.Date(
+					2024, 4, 22, 0, 00, 00, 000000000,
+					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+				),
+			},
+		},
+	))
+
+}

--- a/pkg/utils/rfctime/rfc3339_test.go
+++ b/pkg/utils/rfctime/rfc3339_test.go
@@ -99,23 +99,6 @@ func TestRFC3339(t *testing.T) {
 		})
 	})
 }
-func Test_StringWithLocalTimeZone(t *testing.T) {
-	t.Run("it should return local time zone when passed format without local time zone", func(t *testing.T) {
-		s := "2024-04-02"
-		testee := rfctime.RFC3339(try.To(time.Parse(time.DateOnly, s)).OrFatal(t))
-
-		actual, err := testee.StringWithLocalTimeZone()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		expected := "2024-04-02T09:00:00+09:00"
-		if actual != expected {
-			t.Errorf("unmatch: (actual, expected) = (%s, %s)", actual, expected)
-		}
-	})
-}
-
 func Test_ParseLooseRFC3339(t *testing.T) {
 	type when struct {
 		args []string
@@ -165,11 +148,11 @@ func Test_ParseLooseRFC3339(t *testing.T) {
 				),
 				time.Date(
 					2024, 4, 22, 12, 34, 56, 987654321,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					time.Local,
 				),
 				time.Date(
 					2024, 4, 22, 12, 34, 56, 987654321,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					time.Local,
 				),
 			},
 		},
@@ -188,20 +171,20 @@ func Test_ParseLooseRFC3339(t *testing.T) {
 		then{
 			expected: []time.Time{
 				time.Date(
-					2024, 4, 22, 12, 34, 56, 000000000,
+					2024, 4, 22, 12, 34, 56, 0,
 					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
 				),
 				time.Date(
-					2024, 4, 22, 12, 34, 56, 000000000,
+					2024, 4, 22, 12, 34, 56, 0,
 					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
 				),
 				time.Date(
-					2024, 4, 22, 12, 34, 56, 000000000,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					2024, 4, 22, 12, 34, 56, 0,
+					time.Local,
 				),
 				time.Date(
-					2024, 4, 22, 12, 34, 56, 000000000,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					2024, 4, 22, 12, 34, 56, 0,
+					time.Local,
 				),
 			},
 		},
@@ -219,20 +202,20 @@ func Test_ParseLooseRFC3339(t *testing.T) {
 		then{
 			expected: []time.Time{
 				time.Date(
-					2024, 4, 22, 12, 34, 00, 000000000,
+					2024, 4, 22, 12, 34, 00, 0,
 					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
 				),
 				time.Date(
-					2024, 4, 22, 12, 34, 00, 000000000,
+					2024, 4, 22, 12, 34, 00, 0,
 					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
 				),
 				time.Date(
-					2024, 4, 22, 12, 34, 00, 000000000,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					2024, 4, 22, 12, 34, 00, 0,
+					time.Local,
 				),
 				time.Date(
-					2024, 4, 22, 12, 34, 00, 000000000,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					2024, 4, 22, 12, 34, 00, 0,
+					time.Local,
 				),
 			},
 		},
@@ -250,20 +233,20 @@ func Test_ParseLooseRFC3339(t *testing.T) {
 		then{
 			expected: []time.Time{
 				time.Date(
-					2024, 4, 22, 12, 00, 00, 000000000,
+					2024, 4, 22, 12, 00, 00, 0,
 					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
 				),
 				time.Date(
-					2024, 4, 22, 12, 00, 00, 000000000,
+					2024, 4, 22, 12, 00, 00, 0,
 					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
 				),
 				time.Date(
-					2024, 4, 22, 12, 00, 00, 000000000,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					2024, 4, 22, 12, 00, 00, 0,
+					time.Local,
 				),
 				time.Date(
-					2024, 4, 22, 12, 00, 00, 000000000,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					2024, 4, 22, 12, 00, 00, 0,
+					time.Local,
 				),
 			},
 		},
@@ -279,12 +262,12 @@ func Test_ParseLooseRFC3339(t *testing.T) {
 		then{
 			expected: []time.Time{
 				time.Date(
-					2024, 4, 22, 00, 00, 00, 000000000,
+					2024, 4, 22, 00, 00, 00, 0,
 					time.FixedZone("+07:00", int((7*time.Hour).Seconds())),
 				),
 				time.Date(
-					2024, 4, 22, 0, 00, 00, 000000000,
-					time.FixedZone("+09:00", int((9*time.Hour).Seconds())),
+					2024, 4, 22, 0, 00, 00, 0,
+					time.Local,
 				),
 			},
 		},

--- a/pkg/utils/rfctime/rfc3339_test.go
+++ b/pkg/utils/rfctime/rfc3339_test.go
@@ -99,3 +99,19 @@ func TestRFC3339(t *testing.T) {
 		})
 	})
 }
+func Test_StringWithLocalTimeZone(t *testing.T) {
+	t.Run("it should return local time zone when passed format without local time zone", func(t *testing.T) {
+		s := "2024-04-02"
+		testee := rfctime.RFC3339(try.To(time.Parse(time.DateOnly, s)).OrFatal(t))
+
+		actual, err := testee.StringWithLocalTimeZone()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := "2024-04-02T09:00:00+09:00"
+		if actual != expected {
+			t.Errorf("unmatch: (actual, expected) = (%s, %s)", actual, expected)
+		}
+	})
+}


### PR DESCRIPTION
# This PR

Enable querying by the range of updated_at in `knit data find similar to the following pull request.
https://github.com/opst/knitfab/pull/69

Add new  two flags, `--since` and `--duration`.

## Related Issue
close #19 