### PR TITLE
fix build script: generates an executable `knit` with `./build/build.sh` without `--release`

### DIFF
--- a/build/lib/cli.sh
+++ b/build/lib/cli.sh
@@ -15,7 +15,10 @@ case ${BUILD_MODE} in
 			EXT=".exe"
 		fi
 		echo "build cli 'knit${EXT}' @ ${DEST}" >&2
-		go build ${LDFLAGS:+-ldflags} ${LDFLAGS} -o ${DEST}/knit${EXT} .
+		(
+			cd ${ROOT}/cmd/knit
+			go build ${LDFLAGS:+-ldflags} ${LDFLAGS} -o ${DEST}/knit${EXT} .
+		)
 		exit
 	;;
 	*)


### PR DESCRIPTION
# About This PR

Fix the build script to generate `knit` CLI in developper build.

# Related Issues

- closes #79 