### PR TITLE
Bugfix/#86/cert path

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 ARG GOVERSION=1.22.2-bullseye
 ARG GCFLAGS=""
 ARG LDFLAGS=""
-ARG REPOSITORY_PATH=""
+ARG REPOSITORY=""
 
 #
 # build!
@@ -43,8 +43,8 @@ COPY --from=dlv-installer --chown=nobody:nobody /go/bin/dlv /go/bin/dlv
 # package!
 #
 FROM --platform=${TARGETPLATFORM} base as knitd
-ARG REPOSITORY_PATH
-LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY_PATH}"
+ARG REPOSITORY
+LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY}"
 VOLUME /knit/configs
 ENTRYPOINT ["/knit/knitd"]
 COPY --from=builder --chown=nobody:nobody /dest/knitd /knit/knitd
@@ -56,8 +56,8 @@ COPY --from=builder --chown=nobody:nobody /dest/knitd /knit/knitd
 
 
 FROM --platform=${TARGETPLATFORM} base as knitd-backend
-ARG REPOSITORY_PATH
-LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY_PATH}"
+ARG REPOSITORY
+LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY}"
 VOLUME /knit/configs
 ENTRYPOINT ["/knit/knitd_backend"]
 CMD ["--config", "/knit/configs/knit.backend.yml"]
@@ -71,8 +71,8 @@ COPY --from=builder --chown=nobody:nobody /dest/knitd_backend /knit/knitd_backen
 
 
 FROM --platform=${TARGETPLATFORM} base as knit-vex
-ARG REPOSITORY_PATH
-LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY_PATH}"
+ARG REPOSITORY
+LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY}"
 VOLUME /knit/configs
 ENTRYPOINT ["/knit/vex"]
 CMD ["--storage", "5Gi", "--delta", "5Gi"]
@@ -87,8 +87,8 @@ COPY --from=builder --chown=nobody:nobody /dest/vex /knit/vex
 
 
 FROM --platform=${TARGETPLATFORM} base as knit-dataagt
-ARG REPOSITORY_PATH
-LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY_PATH}"
+ARG REPOSITORY
+LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY}"
 EXPOSE 8080
 VOLUME /knit/mount
 ENTRYPOINT ["/knit/dataagt"]
@@ -102,8 +102,8 @@ COPY --from=builder --chown=nobody:nobody /dest/dataagt /knit/dataagt
 
 
 FROM --platform=${TARGETPLATFORM} base as knit-empty
-ARG REPOSITORY_PATH
-LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY_PATH}"
+ARG REPOSITORY
+LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY}"
 ENTRYPOINT ["/knit/empty"]
 COPY --from=builder --chown=nobody:nobody /dest/empty /knit/empty
 
@@ -114,8 +114,8 @@ COPY --from=builder --chown=nobody:nobody /dest/empty /knit/empty
 
 
 FROM --platform=${TARGETPLATFORM} base as knit-nurse
-ARG REPOSITORY_PATH
-LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY_PATH}"
+ARG REPOSITORY
+LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY}"
 ENTRYPOINT ["/knit/log_recorder"]
 COPY --from=builder --chown=nobody:nobody /dest/log_recorder /knit/log_recorder
 
@@ -126,8 +126,8 @@ COPY --from=builder --chown=nobody:nobody /dest/log_recorder /knit/log_recorder
 
 
 FROM --platform=${TARGETPLATFORM} base as knit-loops
-ARG REPOSITORY_PATH
-LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY_PATH}"
+ARG REPOSITORY
+LABEL org.opencontainers.image.source="https://github.com/${REPOSITORY}"
 ENTRYPOINT ["/knit/loops"]
 COPY --from=builder --chown=nobody:nobody /dest/loops /knit/loops
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -64,15 +64,13 @@ case ${BUILD_MODE} in
 		fi
 
 		export IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io}
-		export CHART_REGISTRY=${CHART_REGISTRY:-https://raw.githubusercontent.com}
-		REPOSITORY_PATH=${REPOSITORY_PATH:-opst/knitfab}
+		REPOSITORY=${REPOSITORY:-opst/knitfab}
 		export ARCH=${ARCH:-"arm64 amd64"}
 		export OS=${OS:-"linux windows darwin"}
 	;;
 	local|test)
 		export IMAGE_REGISTRY=${IMAGE_REGISTRY:-}
-		export CHART_REGISTRY=${ROOT}
-		REPOSITORY_PATH=${REPOSITORY_PATH:-}
+		REPOSITORY=${REPOSITORY:-}
 		export ARCH=${ARCH:-local}
 		export OS=${OS:-}
 	;;
@@ -84,28 +82,28 @@ esac
 export BUILD_MODE
 
 
-case ${REPOSITORY_PATH} in
+case ${REPOSITORY} in
 	git://*)
 		# git repository
-		REMOTE_URL=$(git remote get-url ${REPOSITORY_PATH:6})
+		REMOTE_URL=$(git remote get-url ${REPOSITORY:6})
 		case ${REMOTE_URL} in
 			https://*/*.git)
-				REPOSITORY_PATH=${REMOTE_URL#https://*/}
-				REPOSITORY_PATH=${REPOSITORY_PATH%.git}
+				REPOSITORY=${REMOTE_URL#https://*/}
+				REPOSITORY=${REPOSITORY%.git}
 				;;
 			*@*:*.git)
-				REPOSITORY_PATH=${REMOTE_URL#*@*:}
-				REPOSITORY_PATH=${REPOSITORY_PATH%.git}
+				REPOSITORY=${REMOTE_URL#*@*:}
+				REPOSITORY=${REPOSITORY%.git}
 				;;
 			*)
 				echo "unknown repository: ${REMOTE_URL}" >&2
 				exit 1
 				;;
 		esac
-		echo "detected REPOSITORY_PATH=${REPOSITORY_PATH}"
+		echo "detected REPOSITORY=${REPOSITORY}"
 		;;
 esac
-export REPOSITORY_PATH
+export REPOSITORY
 
 if [ -z "${EXPLICIT_BUILD_TARGET}" ] ; then
 	BUILD_IMAGE=true

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       target: knit-dataagt
       args:
         - LDFLAGS="-s"
-        - REPOSITORY_PATH=${REPOSITORY_PATH}
+        - REPOSITORY=${REPOSITORY}
     image: "knit-dataagt:${TAG}"
   knit-dataagt-debug:
     build:
@@ -32,7 +32,7 @@ services:
       target: knit-vex
       args:
         - LDFLAGS="-s"
-        - REPOSITORY_PATH=${REPOSITORY_PATH}
+        - REPOSITORY=${REPOSITORY}
     image: "knit-vex:${TAG}"
   knit-vex-debug:
     build:
@@ -48,7 +48,7 @@ services:
       target: knit-empty
       args:
         - LDFLAGS="-s"
-        - REPOSITORY_PATH=${REPOSITORY_PATH}
+        - REPOSITORY=${REPOSITORY}
     image: "knit-empty:${TAG}"
   knit-empty-debug:
     build:
@@ -63,7 +63,7 @@ services:
       target: knit-nurse
       args:
         - LDFLAGS="-s"
-        - REPOSITORY_PATH=${REPOSITORY_PATH}
+        - REPOSITORY=${REPOSITORY}
     image: "knit-nurse:${TAG}"
   knit-nurse-debug:
     build:
@@ -78,7 +78,7 @@ services:
       target: knit-loops
       args:
         - LDFLAGS="-s"
-        - REPOSITORY_PATH=${REPOSITORY_PATH}
+        - REPOSITORY=${REPOSITORY}
     image: "knit-loops:${TAG}"
   knit-loops-debug:
     build:
@@ -94,7 +94,7 @@ services:
       target: knitd
       args:
         - LDFLAGS="-s"
-        - REPOSITORY_PATH=${REPOSITORY_PATH}
+        - REPOSITORY=${REPOSITORY}
     image: "knitd:${TAG}"
   knitd-debug:
     build:
@@ -110,7 +110,7 @@ services:
       target: knitd-backend
       args:
         - LDFLAGS="-s"
-        - REPOSITORY_PATH=${REPOSITORY_PATH}
+        - REPOSITORY=${REPOSITORY}
     image: "knitd-backend:${TAG}"
   knitd-backend-debug:
     build:

--- a/build/lib/chart.sh
+++ b/build/lib/chart.sh
@@ -56,5 +56,5 @@ for CHART in knit-app knit-certs knit-db-postgres knit-image-registry knit-stora
 done
 (
 	cd ${CHART_ROOT};
-	${HELM} repo index --merge ./index.yaml .;
+	${HELM} repo index --url ./ --merge ./index.yaml .;
 )

--- a/build/lib/chart.sh
+++ b/build/lib/chart.sh
@@ -7,28 +7,6 @@ DEST=${DEST:-${ROOT}/charts}
 
 HELM=${HELM:-helm}
 
-CHART_REGISTRY=${CHART_REGISTRY:-}   # e.g. http://raw.githubusercontent.com
-REPOSITORY_PATH=${REPOSITORY_PATH:-} # e.g. opst/knitfab
-BRANCH=${BRANCH:-main}
-if [ -n "${CHART_REGISTRY}" ] ; then
-	CHART_REPOSITORY="${CHART_REGISTRY}"  # https://raw.githubusercontent.com/opst/knitfab
-	if [ -n "${REPOSITORY_PATH}" ] ; then
-		CHART_REPOSITORY="${CHART_REPOSITORY}/${REPOSITORY_PATH}"
-		if [ -n "${BRANCH}" ] ; then
-			CHART_REPOSITORY="${CHART_REPOSITORY}/${BRANCH}"
-		fi
-	fi
-
-elif [ "release" = "${BUILD_MODE}" ] ; then
-	echo "CHART_REGISTRY and REPOSITORY_PATH is not specified!" >&2
-	exit 1
-fi
-
-if [ -z "${APP_VERSION}" ] ; then
-	echo "knit app version is not specified!" >&2
-	exit 1
-fi
-
 if [ -z "${CHART_VERSION}" ] ; then
 	echo "knit chart version is not specified!" >&2
 	exit 1
@@ -70,15 +48,13 @@ if [ -n "${DEBUG}" ] ; then
 	cp -r ${HERE}/../debugger-extras/* ${CHART_DEST}/knit-app/templates
 fi
 
-if [ -n "${CHART_REPOSITORY}" ] ; then
-	for CHART in knit-app knit-certs knit-db-postgres knit-image-registry knit-storage-nfs ; do
-		(
-			cd ${CHART_DEST};
-			${HELM} package -u ${CHART};
-		)
-	done
+for CHART in knit-app knit-certs knit-db-postgres knit-image-registry knit-storage-nfs ; do
 	(
-		cd ${CHART_ROOT};
-		${HELM} repo index --merge ./index.yaml --url "${CHART_REPOSITORY}/charts/${BUILD_MODE}" .;
+		cd ${CHART_DEST};
+		${HELM} package -u ${CHART};
 	)
-fi
+done
+(
+	cd ${CHART_ROOT};
+	${HELM} repo index --merge ./index.yaml .;
+)

--- a/build/lib/images.sh
+++ b/build/lib/images.sh
@@ -18,7 +18,7 @@ if [ -n "${DEBUG}" ]; then
 fi
 
 IMAGE_REGISTRY=${IMAGE_REGISTRY:-}  # e.g. ghcr.io
-REPOSITORY=${REPOSITORY:-}          # e.g. opst/knitfab
+export REPOSITORY=${REPOSITORY:-}          # e.g. opst/knitfab
 if [ -n "${IMAGE_REGISTRY}" ] && [ -n "${REPOSITORY}" ] ; then
 	IMAGE_REPOSITORY="${IMAGE_REGISTRY}/${REPOSITORY}"  # ghcr.io/opst/knitfab
 fi
@@ -89,13 +89,13 @@ EOF
 			VAR="${COMP}:${APP_VERSION}-${A}"
 			VARIANTS="${VARIANTS} ${IMAGE_REPOSITORY}/${VAR}"
 			echo "${DOCKER} tag \"${VAR}\" \"${IMAGE_REPOSITORY}/${VAR}\"" >> ${DEST}/publish.sh
-			echo "while !${DOCKER} push \"${IMAGE_REPOSITORY}/${VAR}\"; do echo 'retry...'; sleep 1; done" >> ${DEST}/publish.sh
+			echo "while ! ${DOCKER} push \"${IMAGE_REPOSITORY}/${VAR}\"; do echo 'retry...'; sleep 1; done" >> ${DEST}/publish.sh
 			echo "" >> ${DEST}/publish.sh
 		done
 
 		if [ -n "${VARIANTS}" ] ; then
-			echo "${DOCKER} manifest create \"${IMAGE_REPOSITORY}/${COMP}:${APP_VERSION}\" ${VARIANTS}" >> ${DEST}/publish.sh
-			echo "whils !${DOCKER} manifest push --purge \"${IMAGE_REPOSITORY}/${COMP}:${APP_VERSION}\"; do echo 'retry...'; sleep 1; done" >> ${DEST}/publish.sh
+			echo "${DOCKER} manifest create --amend \"${IMAGE_REPOSITORY}/${COMP}:${APP_VERSION}\" ${VARIANTS}" >> ${DEST}/publish.sh
+			echo "while ! ${DOCKER} manifest push --purge \"${IMAGE_REPOSITORY}/${COMP}:${APP_VERSION}\"; do echo 'retry...'; sleep 1; done" >> ${DEST}/publish.sh
 		else
 			echo "echo \"no image to publish for ${COMP}\" >&2" >> ${DEST}/publish.sh
 		fi

--- a/build/lib/images.sh
+++ b/build/lib/images.sh
@@ -17,10 +17,10 @@ if [ -n "${DEBUG}" ]; then
 	SUFFIX="-debug"
 fi
 
-IMAGE_REGISTRY=${IMAGE_REGISTRY:-}   # e.g. ghcr.io
-REPOSITORY_PATH=${REPOSITORY_PATH:-} # e.g. opst/knitfab
-if [ -n "${IMAGE_REGISTRY}" ] && [ -n "${REPOSITORY_PATH}" ] ; then
-	IMAGE_REPOSITORY="${IMAGE_REGISTRY}/${REPOSITORY_PATH}"  # ghcr.io/opst/knitfab
+IMAGE_REGISTRY=${IMAGE_REGISTRY:-}  # e.g. ghcr.io
+REPOSITORY=${REPOSITORY:-}          # e.g. opst/knitfab
+if [ -n "${IMAGE_REGISTRY}" ] && [ -n "${REPOSITORY}" ] ; then
+	IMAGE_REPOSITORY="${IMAGE_REGISTRY}/${REPOSITORY}"  # ghcr.io/opst/knitfab
 fi
 
 # build images...
@@ -89,13 +89,13 @@ EOF
 			VAR="${COMP}:${APP_VERSION}-${A}"
 			VARIANTS="${VARIANTS} ${IMAGE_REPOSITORY}/${VAR}"
 			echo "${DOCKER} tag \"${VAR}\" \"${IMAGE_REPOSITORY}/${VAR}\"" >> ${DEST}/publish.sh
-			echo "${DOCKER} push \"${IMAGE_REPOSITORY}/${VAR}\"" >> ${DEST}/publish.sh
+			echo "while !${DOCKER} push \"${IMAGE_REPOSITORY}/${VAR}\"; do echo 'retry...'; sleep 1; done" >> ${DEST}/publish.sh
 			echo "" >> ${DEST}/publish.sh
 		done
 
 		if [ -n "${VARIANTS}" ] ; then
 			echo "${DOCKER} manifest create \"${IMAGE_REPOSITORY}/${COMP}:${APP_VERSION}\" ${VARIANTS}" >> ${DEST}/publish.sh
-			echo "${DOCKER} manifest push --purge \"${IMAGE_REPOSITORY}/${COMP}:${APP_VERSION}\"" >> ${DEST}/publish.sh
+			echo "whils !${DOCKER} manifest push --purge \"${IMAGE_REPOSITORY}/${COMP}:${APP_VERSION}\"; do echo 'retry...'; sleep 1; done" >> ${DEST}/publish.sh
 		else
 			echo "echo \"no image to publish for ${COMP}\" >&2" >> ${DEST}/publish.sh
 		fi


### PR DESCRIPTION
# About This PR

Fix installer.

- When relative filepath of TLS certifications and their Key are given, they are handled as relative filepath from current directory, not install setting directory.

Fix build pipeline.

- Rename environmental varialble from `REPOSITORY_PATH` to `REPOSITORY`, for simplicity.
- Image publishing script now retries when fail pushing an image/a manifest to ghcr.io

## Related Issue

- closes #86