### PR TITLE
Clean repo after `./dev-cluster/install-knit.sh`

### DIFF
--- a/dev-cluster/install-knit.sh
+++ b/dev-cluster/install-knit.sh
@@ -4,6 +4,7 @@ set -e
 HERE=$(cd ${0%/*}; pwd)
 ROOT=$(cd ${HERE}/../; pwd)
 JQ=${JQ:-jq}
+HELM=${HELM:-helm}
 KUBECTL=${KUBECTL:-kubectl}
 export KUBECONFIG=${KUBECONFIG:-${HERE}/.sync/kubeconfig/kubeconfig}
 export NAMESPACE=${NAMESPACE:-knit-dev}
@@ -38,3 +39,4 @@ export IMAGE_REPOSITORY_HOST="localhost:30005"
 export REPOSITORY=local
 export CHART_REPOSITORY_ROOT="file://${ROOT}/charts/local"
 ${ROOT}/installer/installer.sh --install -s ${HERE}/knitfab-install-settings --version ${VERSION} ${ARGS}
+${HELM} repo remove knitfab


### PR DESCRIPTION
# About This PR

`file://`-protrocol is not standard for helm.
Once repo with such protocol is registered, after `helm install -u` will fail.

## Related Issue

- close #102 