### PR TITLE
schema-upgrader: pass RDB User & Password via envirionemtal variable, not URL.

### DIFF
--- a/cmd/schema_upgrader/main.go
+++ b/cmd/schema_upgrader/main.go
@@ -82,11 +82,18 @@ func main() {
 				}
 			}
 
+			if flags.User != "" {
+				os.Setenv("PGUSER", flags.User)
+			}
+			if flags.Password != "" {
+				os.Setenv("PGPASSWORD", flags.Password)
+			}
+
 			db, err := postgres.New(
 				ctx,
 				fmt.Sprintf(
-					"postgres://%s:%s@%s:%d/%s",
-					flags.User, flags.Password, flags.Host, flags.Port, flags.Database,
+					"postgres://%s:%d/%s",
+					flags.Host, flags.Port, flags.Database,
 				),
 				postgres.WithSchemaRepository(flags.Schema),
 			)


### PR DESCRIPTION
# About This PR

Stop concat credentials into URL, and pass them via environemntal variable.

By this change, any URL special characters in database credentials does not matter no longer.

## Related Issues

- fixes #111 .

