### PR TITLE
add no-vex mode

### DIFF
--- a/charts/src/knit-app/templates/vex.yaml
+++ b/charts/src/knit-app/templates/vex.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.vex.use }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -151,3 +152,4 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+{{ end }}

--- a/charts/src/knit-app/values.yaml
+++ b/charts/src/knit-app/values.yaml
@@ -25,7 +25,14 @@ knitd_backend:
 vex:
   component: vex
   image: "knit-vex"
+
+  # use: if true, vex will be deployed.
+  use: false
+
+  # margin: the minimum size of the volume capacity reminder.
   margin: 1Gi
+
+  # delta: the volume growth size for a step.
   delta: 5Gi
 
 # # # empty container # # #

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -183,7 +183,7 @@ EOF
 
 	echo ${NAMESPACE:-knitfab} > ./namespace
 
-	cat <<EOF >> values/knit-app.yaml
+	cat <<EOF > values/knit-app.yaml
 # # # values/knit-app.yaml # # #
 
 # this file declares install paramaters for knit-app.
@@ -197,10 +197,22 @@ knitd:
   # port: Port number of knit-api service, exposed from k8s cluster node.
   port: 30803
 
+vex:
+  # use: If true, vex is deployed. default: false
+  use: false
+
+  # # # items below are effective only when vex.use is true. # # #
+
+  # # margin: the minimum size of the volume capacity reminder.
+  # margin: 1Gi
+
+  # # delta: the volume growth size for a step.
+  # delta: 5Gi
+
 EOF
 
 	cat <<EOF >> values/knit-db-postgres.yaml
-# # # values/knit-app.yaml # # #
+# # # values/knit-db-postgres.yaml # # #
 
 # # this file declares install paramaters for Database of Knitfab.
 


### PR DESCRIPTION
# About This PR

As long as we using NFS for the storage backend, capacities of PV is not matter.
Regardless of resource requirement of PV/PVC, it can be written data as much as NFS capacity.

So, vex is not effective in standard installation.

By this change, Knitfab provide "no-vex mode", omitting vex in installing, and it is default.

## Related Issue

- closes #91 