### PR TITLE
`knit data push`: Can abort sending files.

### DIFF
--- a/cmd/knit/subcommands/data/push/command.go
+++ b/cmd/knit/subcommands/data/push/command.go
@@ -140,6 +140,7 @@ func Task(
 				bar.SetTotal(prog.EstimatedTotalSize())
 				bar.SetCurrent(prog.ProgressedSize())
 				bar.Set("prefix", "")
+			case <-prog.Done():
 			}
 			break
 		}


### PR DESCRIPTION
# About This PR

`knit data push` has a flaw that it does not stop sending file when Ctrl+C is hit.

By this change, fix the flaw. `knit data push` can abort sending file.

## Related Issue

- closes #104 