### PR TITLE
Run Management Loop and Finishing Loop supports Pseudo Plan `knit#imported`

### DIFF
--- a/cmd/loops/looper.go
+++ b/cmd/loops/looper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opst/knitfab/cmd/loops/tasks/runManagement"
 	"github.com/opst/knitfab/cmd/loops/tasks/runManagement/manager"
 	"github.com/opst/knitfab/cmd/loops/tasks/runManagement/manager/image"
+	"github.com/opst/knitfab/cmd/loops/tasks/runManagement/manager/imported"
 	"github.com/opst/knitfab/cmd/loops/tasks/runManagement/manager/uploaded"
 	knit "github.com/opst/knitfab/pkg"
 	api_runs "github.com/opst/knitfab/pkg/api/types/runs"
@@ -162,6 +163,7 @@ func StartLoop(
 			kdb.Uploaded: uploaded.New(
 				kcluster.Database().Data(),
 			),
+			kdb.Imported: imported.New(),
 		}
 		_, err := loop.Start(
 			ctx,
@@ -191,6 +193,7 @@ func StartLoop(
 	case kdb.Finishing:
 		pseudoPlanNames := []kdb.PseudoPlanName{
 			kdb.Uploaded,
+			kdb.Imported,
 		}
 		// Initial RunCursor
 		runCursor := finishing.Seed(pseudoPlanNames)

--- a/cmd/loops/tasks/runManagement/manager/imported/imported.go
+++ b/cmd/loops/tasks/runManagement/manager/imported/imported.go
@@ -1,0 +1,26 @@
+package imported
+
+import (
+	"context"
+
+	"github.com/opst/knitfab/cmd/loops/hook"
+	"github.com/opst/knitfab/cmd/loops/tasks/runManagement/manager"
+	api_runs "github.com/opst/knitfab/pkg/api/types/runs"
+	kdb "github.com/opst/knitfab/pkg/db"
+)
+
+const PLAN_NAME = kdb.Imported
+
+func New() manager.Manager {
+	return func(ctx context.Context, h hook.Hook[api_runs.Detail], r kdb.Run) (kdb.KnitRunStatus, error) {
+		// Imported Runs comes here are expired its `"lifecycle_suspend_until"`.
+		// They should be aborted.
+		if r.Status == kdb.Running {
+			if err := h.Before(api_runs.ComposeDetail(r)); err != nil {
+				return r.Status, err
+			}
+			return kdb.Aborting, nil
+		}
+		return r.Status, nil
+	}
+}

--- a/cmd/loops/tasks/runManagement/manager/imported/imported_test.go
+++ b/cmd/loops/tasks/runManagement/manager/imported/imported_test.go
@@ -1,0 +1,102 @@
+package imported_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/opst/knitfab/cmd/loops/hook"
+	"github.com/opst/knitfab/cmd/loops/tasks/runManagement/manager/imported"
+	api_runs "github.com/opst/knitfab/pkg/api/types/runs"
+	kdb "github.com/opst/knitfab/pkg/db"
+	"github.com/opst/knitfab/pkg/utils/try"
+)
+
+func TestImportedManager(t *testing.T) {
+	t.Run("Do not change state:", func(t *testing.T) {
+
+		theory := func(when kdb.KnitRunStatus) func(*testing.T) {
+			return func(t *testing.T) {
+				run := kdb.Run{
+					RunBody: kdb.RunBody{
+						Status: when,
+					},
+				}
+
+				hookIsCalled := false
+				hooks := hook.Func[api_runs.Detail]{
+					BeforeFn: func(d api_runs.Detail) error {
+						hookIsCalled = true
+						return nil
+					},
+				}
+
+				testee := imported.New()
+				got := try.To(testee(context.Background(), hooks, run)).OrFatal(t)
+
+				if got != when {
+					t.Errorf("Expected status %v, got %v", when, got)
+				}
+
+				if hookIsCalled {
+					t.Errorf("Hook should not be called")
+				}
+			}
+		}
+
+		t.Run("Starting", theory(kdb.Starting))
+		t.Run("Ready", theory(kdb.Ready))
+	})
+
+	t.Run("Change Run state from Running to Aborting", func(t *testing.T) {
+		run := kdb.Run{
+			RunBody: kdb.RunBody{
+				Status: kdb.Running,
+			},
+		}
+
+		hookIsCalled := false
+		hooks := hook.Func[api_runs.Detail]{
+			BeforeFn: func(d api_runs.Detail) error {
+				hookIsCalled = true
+				return nil
+			},
+		}
+
+		testee := imported.New()
+		got := try.To(testee(context.Background(), hooks, run)).OrFatal(t)
+
+		if got != kdb.Aborting {
+			t.Errorf("Expected status %v, got %v", kdb.Aborting, got)
+		}
+
+		if !hookIsCalled {
+			t.Errorf("Hook should be called")
+		}
+	})
+
+	t.Run("Do not change Run state from Running if hook causes an error", func(t *testing.T) {
+		run := kdb.Run{
+			RunBody: kdb.RunBody{
+				Status: kdb.Running,
+			},
+		}
+
+		expectedErr := errors.New("expected error")
+		hooks := hook.Func[api_runs.Detail]{
+			BeforeFn: func(d api_runs.Detail) error {
+				return expectedErr
+			},
+		}
+
+		testee := imported.New()
+		got, gotErr := testee(context.Background(), hooks, run)
+
+		if got != kdb.Running {
+			t.Errorf("Expected status %v, got %v", kdb.Running, got)
+		}
+		if !errors.Is(gotErr, expectedErr) {
+			t.Errorf("Expected error %v, got %v", expectedErr, gotErr)
+		}
+	})
+}


### PR DESCRIPTION
## About This PR

For a Run of Pseudo Plan `knit#imported`,

- Run Management Loop change state from `Running` to `Aborting` if its `lifecycle_suspend_until` is over
- Finishing Loop supports them

## Related Issues

- close #121