### PR TITLE
Fix/#149/mount failure dataagt

### DIFF
--- a/charts/src/knit-app/templates/knitd-backend.yaml
+++ b/charts/src/knit-app/templates/knitd-backend.yaml
@@ -66,6 +66,9 @@ rules:
     resources: ["secrets"]
     resourceNames: ["{{ .Values.knitd_backend.component }}-signer-for-import-token"]
     verbs: ["get", "create", "update", "patch"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["list"]
 
 
 ---

--- a/charts/src/knit-app/templates/loops.yaml
+++ b/charts/src/knit-app/templates/loops.yaml
@@ -755,3 +755,48 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ .Values.loops.gc.serviceAccount }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: subscribe-events
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/part-of: knitfab
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grant-subscribe-events
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/part-of: knitfab
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: knit-loops
+    app.kubernetes.io/name: grant-subscribe-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: subscribe-events
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.loops.run_management.serviceAccount }}
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.loops.housekeeping.serviceAccount }}

--- a/cmd/knitd_backend/handlers/utils_for_test.go
+++ b/cmd/knitd_backend/handlers/utils_for_test.go
@@ -20,6 +20,7 @@ import (
 	kio "github.com/opst/knitfab/pkg/io"
 	"github.com/opst/knitfab/pkg/utils"
 	"github.com/opst/knitfab/pkg/workloads/dataagt"
+	"github.com/opst/knitfab/pkg/workloads/k8s"
 	"github.com/opst/knitfab/pkg/workloads/worker"
 )
 
@@ -345,7 +346,7 @@ func (m *MockedDataagt) String() string {
 type mockWorker struct {
 	Impl struct {
 		RunId     func() string
-		JobStatus func() worker.Status
+		JobStatus func() k8s.JobStatus
 		ExitCode  func() (uint8, string, bool)
 		Log       func(context.Context) (io.ReadCloser, error)
 		Close     func() error
@@ -373,18 +374,10 @@ func (m *mockWorker) RunId() string {
 	panic(errors.New("it should not be called"))
 }
 
-func (m *mockWorker) JobStatus() worker.Status {
+func (m *mockWorker) JobStatus(ctx context.Context) k8s.JobStatus {
 	m.Calls.JobStatus.Args = append(m.Calls.JobStatus.Args, nil)
 	if m.Impl.JobStatus != nil {
 		return m.Impl.JobStatus()
-	}
-	panic(errors.New("it should not be called"))
-}
-
-func (m *mockWorker) ExitCode() (uint8, string, bool) {
-	m.Calls.ExitCode.Args = append(m.Calls.ExitCode.Args, nil)
-	if m.Impl.ExitCode != nil {
-		return m.Impl.ExitCode()
 	}
 	panic(errors.New("it should not be called"))
 }

--- a/cmd/loops/tasks/finishing/finishing_test.go
+++ b/cmd/loops/tasks/finishing/finishing_test.go
@@ -339,7 +339,7 @@ func TestTaskFinishing_Outside_PickAndSetStatus(t *testing.T) {
 
 type FakeWorker struct {
 	runId     string
-	jobStatus worker.Status
+	jobStatus k8s.JobStatus
 	closed    bool
 	closeErr  error
 
@@ -352,7 +352,7 @@ func (fw *FakeWorker) RunId() string {
 	return fw.runId
 }
 
-func (fw *FakeWorker) JobStatus() worker.Status {
+func (fw *FakeWorker) JobStatus(context.Context) k8s.JobStatus {
 	return fw.jobStatus
 }
 
@@ -500,9 +500,11 @@ func TestTaskFinishing_Inside_PickAndSetStatus(t *testing.T) {
 				},
 			},
 			workerFromFind: &FakeWorker{
-				runId:     "run-id-0",
-				jobStatus: worker.Done,
-				closed:    false,
+				runId: "run-id-0",
+				jobStatus: k8s.JobStatus{
+					Type: k8s.Succeeded,
+				},
+				closed: false,
 			},
 		},
 		Then{
@@ -533,7 +535,7 @@ func TestTaskFinishing_Inside_PickAndSetStatus(t *testing.T) {
 			},
 			workerFromFind: &FakeWorker{
 				runId:     "run-id-0",
-				jobStatus: worker.Failed,
+				jobStatus: k8s.JobStatus{Type: k8s.Failed, Code: 1},
 				closed:    false,
 			},
 		},
@@ -713,7 +715,7 @@ func TestTaskFinishing_Inside_PickAndSetStatus(t *testing.T) {
 				},
 				workerFromFind: &FakeWorker{
 					runId:     "run-id-0",
-					jobStatus: worker.Done,
+					jobStatus: k8s.JobStatus{Type: k8s.Succeeded},
 					closeErr:  fakeError,
 				},
 			},

--- a/cmd/loops/tasks/housekeeping/task_test.go
+++ b/cmd/loops/tasks/housekeeping/task_test.go
@@ -17,13 +17,13 @@ import (
 type MockedGetPodder struct {
 	ImplGetPod func(
 		ctx context.Context, backoff retry.Backoff, name string,
-		requirements ...k8s.Requirement[*kubecore.Pod],
+		requirements ...k8s.Requirement[k8s.WithEvents[*kubecore.Pod]],
 	) retry.Promise[k8s.Pod]
 }
 
 func (m *MockedGetPodder) GetPod(
 	ctx context.Context, backoff retry.Backoff, name string,
-	requirements ...k8s.Requirement[*kubecore.Pod],
+	requirements ...k8s.Requirement[k8s.WithEvents[*kubecore.Pod]],
 ) retry.Promise[k8s.Pod] {
 	return m.ImplGetPod(ctx, backoff, name, requirements...)
 }
@@ -199,7 +199,7 @@ func TestTask(t *testing.T) {
 				mGetPodder := &MockedGetPodder{
 					ImplGetPod: func(
 						ctx context.Context, backoff retry.Backoff, name string,
-						requirements ...k8s.Requirement[*kubecore.Pod],
+						_ ...k8s.Requirement[k8s.WithEvents[*kubecore.Pod]],
 					) retry.Promise[k8s.Pod] {
 
 						if name != when.InvokeCallbackWith.Name {
@@ -271,7 +271,7 @@ func TestTask(t *testing.T) {
 				mGetPodder := &MockedGetPodder{
 					ImplGetPod: func(
 						ctx context.Context, backoff retry.Backoff, name string,
-						requirements ...k8s.Requirement[*kubecore.Pod],
+						_ ...k8s.Requirement[k8s.WithEvents[*kubecore.Pod]],
 					) retry.Promise[k8s.Pod] {
 						ch := make(chan retry.Result[k8s.Pod], 1)
 						ch <- retry.Result[k8s.Pod]{
@@ -308,6 +308,16 @@ func TestTask(t *testing.T) {
 
 		t.Run("should close pod if pod status is failed", theory(
 			When{PodStatus: k8s.PodFailed},
+			Then{
+				WantClose: true,
+				CallbackReturns: CallbackReturns{
+					RemoveOk: true, Err: nil,
+				},
+			},
+		))
+
+		t.Run("should close pod if pod status is stucking", theory(
+			When{PodStatus: k8s.PodStucking},
 			Then{
 				WantClose: true,
 				CallbackReturns: CallbackReturns{

--- a/cmd/loops/tasks/housekeeping/task_test.go
+++ b/cmd/loops/tasks/housekeeping/task_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opst/knitfab/pkg/utils/retry"
 	"github.com/opst/knitfab/pkg/workloads/k8s"
 	kubecore "k8s.io/api/core/v1"
+	kubeevents "k8s.io/api/events/v1"
 )
 
 type MockedGetPodder struct {
@@ -58,6 +59,10 @@ func (m *MockPod) Status() k8s.PodPhase {
 func (m *MockPod) Close() error {
 	m.IsClosed = true
 	return m.CloseResult
+}
+
+func (m *MockPod) Events() []kubeevents.Event {
+	return nil
 }
 
 type CallbackReturns struct {

--- a/pkg/workloads/dataagt/dataagt.go
+++ b/pkg/workloads/dataagt/dataagt.go
@@ -11,6 +11,7 @@ import (
 	xe "github.com/opst/knitfab/pkg/errors"
 	"github.com/opst/knitfab/pkg/utils/retry"
 	k8s "github.com/opst/knitfab/pkg/workloads/k8s"
+	kubecore "k8s.io/api/core/v1"
 )
 
 const dataagtPortName = "dataagt-port"
@@ -169,6 +170,16 @@ func Spawn(
 	promPod := kcluster.NewPod(
 		ctx, retry.StaticBackoff(200*time.Millisecond), spec.Pod,
 		k8s.WithCheckpoint(k8s.PodHasBeenPending, pendingDeadline),
+		func(value k8s.WithEvents[*kubecore.Pod]) error {
+			sigev := value.SignificantEvent()
+			if sigev == nil {
+				return nil
+			}
+			if sigev.Type == "Warning" {
+				return fmt.Errorf("data agent cannot start: %s", sigev.Reason)
+			}
+			return nil
+		},
 		k8s.PodHasBeenRunning,
 	)
 

--- a/pkg/workloads/k8s/k8s_test.go
+++ b/pkg/workloads/k8s/k8s_test.go
@@ -1071,8 +1071,8 @@ func TestK8SCluster_Pod(t *testing.T) {
 
 			result := <-testee.NewPod(
 				ctx, retry.StaticBackoff(200*time.Millisecond), podDefn,
-				func(value *kubecore.Pod) error {
-					if value.Status.Phase == testcase.Then.PodPhase {
+				func(value k8s.WithEvents[*kubecore.Pod]) error {
+					if value.Value.Status.Phase == testcase.Then.PodPhase {
 						return nil
 					}
 					return retry.ErrRetry
@@ -1100,8 +1100,8 @@ func TestK8SCluster_Pod(t *testing.T) {
 			{
 				result := <-testee.GetPod(
 					ctx, retry.StaticBackoff(200*time.Millisecond), testcase.When.PodName,
-					func(value *kubecore.Pod) error {
-						if value.Status.Phase == testcase.Then.PodPhase {
+					func(value k8s.WithEvents[*kubecore.Pod]) error {
+						if value.Value.Status.Phase == testcase.Then.PodPhase {
 							return nil
 						}
 						return retry.ErrRetry

--- a/pkg/workloads/k8s/k8s_test.go
+++ b/pkg/workloads/k8s/k8s_test.go
@@ -1123,6 +1123,21 @@ func TestK8SCluster_Pod(t *testing.T) {
 						result.Value.Ports(), testcase.Then.Ports,
 					)
 				}
+
+				{
+					ev := result.Value.Events()
+					if len(ev) == 0 {
+						t.Errorf("pod events is not given.")
+					}
+					for _, e := range ev {
+						if e.Regarding.Kind != "Pod" {
+							t.Errorf("event regarding is not Pod: %v", e)
+						}
+						if e.Regarding.Name != testcase.When.PodName {
+							t.Errorf("event regarding name is wrong: %v", e)
+						}
+					}
+				}
 			}
 
 			{

--- a/pkg/workloads/k8s/mock/utils.go
+++ b/pkg/workloads/k8s/mock/utils.go
@@ -13,6 +13,7 @@ import (
 	kubebatch "k8s.io/api/batch/v1"
 	kubecore "k8s.io/api/core/v1"
 	kubeevents "k8s.io/api/events/v1"
+	kubeapimeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
@@ -101,7 +102,7 @@ type MockClient struct {
 		GetSecret    func(ctx context.Context, namespace string, name string) (*kubecore.Secret, error)
 		DeleteSecret func(ctx context.Context, namespace string, name string) error
 
-		GetEvents func(ctx context.Context, namespace string, sel ...k8s.EventSelector) ([]kubeevents.Event, error)
+		GetEvents func(ctx context.Context, kind string, target kubeapimeta.ObjectMeta) ([]kubeevents.Event, error)
 
 		Log func(ctx context.Context, namespace string, pod string, container string) (io.ReadCloser, error)
 	}
@@ -236,7 +237,7 @@ func (m *MockClient) CreatePod(ctx context.Context, namespace string, pod *kubec
 	if m.Impl.CreatePod == nil {
 		return nil, errors.New("[MOCK] not implemented")
 	}
-	panic("not implemented")
+	return m.Impl.CreatePod(ctx, namespace, pod)
 }
 func (m *MockClient) GetPod(ctx context.Context, namespace string, name string) (*kubecore.Pod, error) {
 	m.Called.GetPod += 1
@@ -244,7 +245,7 @@ func (m *MockClient) GetPod(ctx context.Context, namespace string, name string) 
 	if m.Impl.GetPod == nil {
 		return nil, errors.New("[MOCK] not implemented")
 	}
-	panic("not implemented")
+	return m.Impl.GetPod(ctx, namespace, name)
 }
 func (m *MockClient) DeletePod(ctx context.Context, namespace string, name string) error {
 	m.Called.DeletePod += 1
@@ -252,7 +253,7 @@ func (m *MockClient) DeletePod(ctx context.Context, namespace string, name strin
 	if m.Impl.DeletePod == nil {
 		return errors.New("[MOCK] not implemented")
 	}
-	panic("not implemented")
+	return m.Impl.DeletePod(ctx, namespace, name)
 }
 func (m *MockClient) FindPods(ctx context.Context, namespace string, ls k8s.LabelSelector) ([]kubecore.Pod, error) {
 	m.Called.FindPods += 1
@@ -268,7 +269,7 @@ func (m *MockClient) Log(ctx context.Context, namespace string, pod string, cont
 	if m.Impl.Log == nil {
 		return nil, errors.New("[MOCK] not implemented")
 	}
-	panic("not implemented")
+	return m.Impl.Log(ctx, namespace, pod, container)
 }
 
 func (m *MockClient) UpsertSecret(ctx context.Context, namespace string, spec *applyconfigurations.SecretApplyConfiguration) (*kubecore.Secret, error) {
@@ -298,13 +299,13 @@ func (m *MockClient) DeleteSecret(ctx context.Context, namespace string, name st
 	return m.Impl.DeleteSecret(ctx, namespace, name)
 }
 
-func (m *MockClient) GetEvents(ctx context.Context, namespace string, sel ...k8s.EventSelector) ([]kubeevents.Event, error) {
+func (m *MockClient) GetEvents(ctx context.Context, kind string, target kubeapimeta.ObjectMeta) ([]kubeevents.Event, error) {
 	m.Called.GetEvents += 1
 
 	if m.Impl.GetEvents == nil {
 		return nil, errors.New("[MOCK] not implemented")
 	}
-	return m.Impl.GetEvents(ctx, namespace, sel...)
+	return m.Impl.GetEvents(ctx, kind, target)
 }
 
 func NewMockClient() *MockClient {

--- a/pkg/workloads/k8s/mock/utils.go
+++ b/pkg/workloads/k8s/mock/utils.go
@@ -12,6 +12,7 @@ import (
 	kubeapps "k8s.io/api/apps/v1"
 	kubebatch "k8s.io/api/batch/v1"
 	kubecore "k8s.io/api/core/v1"
+	kubeevents "k8s.io/api/events/v1"
 	applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
@@ -100,6 +101,8 @@ type MockClient struct {
 		GetSecret    func(ctx context.Context, namespace string, name string) (*kubecore.Secret, error)
 		DeleteSecret func(ctx context.Context, namespace string, name string) error
 
+		GetEvents func(ctx context.Context, namespace string, sel ...k8s.EventSelector) ([]kubeevents.Event, error)
+
 		Log func(ctx context.Context, namespace string, pod string, container string) (io.ReadCloser, error)
 	}
 	Called struct {
@@ -127,6 +130,8 @@ type MockClient struct {
 		UpsertSecret uint64
 		GetSecret    uint64
 		DeleteSecret uint64
+
+		GetEvents uint64
 
 		Log uint64
 	}
@@ -291,6 +296,15 @@ func (m *MockClient) DeleteSecret(ctx context.Context, namespace string, name st
 		return errors.New("[MOCK] not implemented")
 	}
 	return m.Impl.DeleteSecret(ctx, namespace, name)
+}
+
+func (m *MockClient) GetEvents(ctx context.Context, namespace string, sel ...k8s.EventSelector) ([]kubeevents.Event, error) {
+	m.Called.GetEvents += 1
+
+	if m.Impl.GetEvents == nil {
+		return nil, errors.New("[MOCK] not implemented")
+	}
+	return m.Impl.GetEvents(ctx, namespace, sel...)
 }
 
 func NewMockClient() *MockClient {

--- a/pkg/workloads/k8s/testenv/k8s.go
+++ b/pkg/workloads/k8s/testenv/k8s.go
@@ -55,9 +55,9 @@ func Images() struct {
 		Nurse   string
 		Empty   string
 	}{
-		Dataagt: kos.GetEnvOr(ENV_IMAGE_DATAAGT, "knit-dataagt:TEST"),
-		Nurse:   kos.GetEnvOr(ENV_IMAGE_NURSE, "knit-nurse:TEST"),
-		Empty:   kos.GetEnvOr(ENV_IMAGE_EMPTY, "knit-empty:TEST"),
+		Dataagt: kos.GetEnvOr(ENV_IMAGE_DATAAGT, "knit-dataagt:TEST-test"),
+		Nurse:   kos.GetEnvOr(ENV_IMAGE_NURSE, "knit-nurse:TEST-test"),
+		Empty:   kos.GetEnvOr(ENV_IMAGE_EMPTY, "knit-empty:TEST-test"),
 	}
 }
 
@@ -536,6 +536,6 @@ func (kc *k8sclient) DeleteSecret(ctx context.Context, namespace string, name st
 	return kc.base.DeleteSecret(ctx, namespace, name)
 }
 
-func (k8s *k8sclient) GetEvents(ctx context.Context, namespace string, sel ...k8s.EventSelector) ([]kubeevent.Event, error) {
-	return k8s.base.GetEvents(ctx, namespace, sel...)
+func (k8s *k8sclient) GetEvents(ctx context.Context, kind string, target kubeapimeta.ObjectMeta) ([]kubeevent.Event, error) {
+	return k8s.base.GetEvents(ctx, kind, target)
 }

--- a/pkg/workloads/k8s/testenv/k8s.go
+++ b/pkg/workloads/k8s/testenv/k8s.go
@@ -17,6 +17,7 @@ import (
 	kubeapps "k8s.io/api/apps/v1"
 	kubebatch "k8s.io/api/batch/v1"
 	kubecore "k8s.io/api/core/v1"
+	kubeevent "k8s.io/api/events/v1"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	kubeapimeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
@@ -533,4 +534,8 @@ func (kc *k8sclient) GetSecret(ctx context.Context, namespace string, name strin
 
 func (kc *k8sclient) DeleteSecret(ctx context.Context, namespace string, name string) error {
 	return kc.base.DeleteSecret(ctx, namespace, name)
+}
+
+func (k8s *k8sclient) GetEvents(ctx context.Context, namespace string, sel ...k8s.EventSelector) ([]kubeevent.Event, error) {
+	return k8s.base.GetEvents(ctx, namespace, sel...)
 }


### PR DESCRIPTION
## About This PR

Make it be able to guess wheather Data Agent and Run's Worker cannot be started.

### Detail

This guess is based on Kubernetes Event.

If the event regarding to a scheduled Pod reported by a controller is "Type: Warning", the Worker or Data Agent having the Pod is assumed to be "stucking".

- If the Data Agent is stucked during starting, the starting is failed with error.
- Housekeeping Loop shutdowns stucking Data Agent.
- When Run Management Loop detects Worker is stucked, let it be "aborting".