### PR TITLE
bump go version to v1.23.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.4.1
 
-ARG GOVERSION=1.22.2-bullseye
+ARG GOVERSION=1.23.1-bullseye
 ARG GCFLAGS=""
 ARG LDFLAGS=""
 ARG REPOSITORY=""

--- a/cmd/dataagt/go.mod
+++ b/cmd/dataagt/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/dataagt
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/cmd/empty/go.mod
+++ b/cmd/empty/go.mod
@@ -1,3 +1,3 @@
 module github.com/opst/knitfab/cmd/empty
 
-go 1.22.0
+go 1.23.1

--- a/cmd/knit/go.mod
+++ b/cmd/knit/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/knit
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/cmd/knitd/go.mod
+++ b/cmd/knitd/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/knitd
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/cmd/knitd_backend/go.mod
+++ b/cmd/knitd_backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/knitd_backend
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/cmd/log_recorder/go.mod
+++ b/cmd/log_recorder/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/log_recorder
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/cmd/loops/go.mod
+++ b/cmd/loops/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/loops
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/cmd/schema_upgrader/go.mod
+++ b/cmd/schema_upgrader/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/schema_manager
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/cmd/volume_expander/go.mod
+++ b/cmd/volume_expander/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab/cmd/volume_expander
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/opst/knitfab v1.2.1 => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opst/knitfab
 
-go 1.22.2
+go 1.23.1
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
## About This PR

Upgrade `go` to build from v1.22.1 to v1.23.1.

closes #148 .