### PR TITLE
Make Plan Annotation mutable

### DIFF
--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -195,6 +195,42 @@ type KnitClient interface {
 	// - error
 	RegisterPlan(ctx context.Context, spec plans.PlanSpec) (plans.Detail, error)
 
+	// SetResources set (or unset) resource limits of plan with given planId.
+	//
+	// Args
+	//
+	// - context.Context
+	//
+	// - string: planId to be updated
+	//
+	// - apiplans.ResourceLimitChange: change of resource limits
+	//
+	// Returns
+	//
+	// - apiplans.Detail: metadata of updated plan
+	//
+	// - error
+	//
+	UpdateResources(ctx context.Context, planId string, res plans.ResourceLimitChange) (plans.Detail, error)
+
+	// UpdateAnnotations update annotations of plan with given planId.
+	//
+	// Args
+	//
+	// - context.Context
+	//
+	// - string: planId to be updated
+	//
+	// - apiplans.AnnotationChange: change of annotations
+	//
+	// Returns
+	//
+	// - apiplans.Detail: metadata of updated plan
+	//
+	// - error
+	//
+	UpdateAnnotations(ctx context.Context, planId string, change plans.AnnotationChange) (plans.Detail, error)
+
 	// GetRun get run detail with given runId.
 	//
 	// Args
@@ -297,9 +333,6 @@ type KnitClient interface {
 	//
 	// - error
 	Retry(ctx context.Context, runId string) error
-
-	// SetResources set (or unset) resource limits of plan with given planId.
-	UpdateResources(ctx context.Context, planId string, res plans.ResourceLimitChange) (plans.Detail, error)
 }
 
 type client struct {

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -46,6 +46,11 @@ type FindRunArgs struct {
 	duration  time.Duration
 }
 
+type UpdateAnnotationsArgs struct {
+	PlanId      string
+	Annotations plans.AnnotationChange
+}
+
 func New(t *testing.T) *mockKnitClient {
 	return &mockKnitClient{t: t}
 }
@@ -104,28 +109,32 @@ type mockKnitClient struct {
 		GetDataRaw     func(context.Context, string, func(io.Reader) error) error
 		GetData        func(context.Context, string, func(rest.FileEntry) error) error
 		FindData       func(ctx context.Context, tags []apitags.Tag, since *time.Time, duration *time.Duration) ([]data.Detail, error)
-		GetPlans       func(ctx context.Context, planId string) (plans.Detail, error)
-		FindPlan       func(
+
+		GetPlans func(ctx context.Context, planId string) (plans.Detail, error)
+		FindPlan func(
 			ctx context.Context, active logic.Ternary, imageVer kdb.ImageIdentifier,
 			inTags []apitags.Tag, outTags []apitags.Tag,
 		) ([]plans.Detail, error)
 		PutPlanForActivate func(ctx context.Context, planId string, isActive bool) (plans.Detail, error)
 		UpdateResources    func(ctx context.Context, runId string, resources plans.ResourceLimitChange) (plans.Detail, error)
 		RegisterPlan       func(ctx context.Context, spec plans.PlanSpec) (plans.Detail, error)
-		GetRun             func(ctx context.Context, runId string) (runs.Detail, error)
-		GetRunLog          func(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
-		FindRun            func(ctx context.Context, query rest.FindRunParameter) ([]runs.Detail, error)
-		Abort              func(ctx context.Context, runId string) (runs.Detail, error)
-		Tearoff            func(ctx context.Context, runId string) (runs.Detail, error)
-		DeleteRun          func(ctx context.Context, runId string) error
-		Retry              func(ctx context.Context, runId string) error
+		UpdateAnnotations  func(ctx context.Context, planId string, annotations plans.AnnotationChange) (plans.Detail, error)
+
+		GetRun    func(ctx context.Context, runId string) (runs.Detail, error)
+		GetRunLog func(ctx context.Context, runId string, follow bool) (io.ReadCloser, error)
+		FindRun   func(ctx context.Context, query rest.FindRunParameter) ([]runs.Detail, error)
+		Abort     func(ctx context.Context, runId string) (runs.Detail, error)
+		Tearoff   func(ctx context.Context, runId string) (runs.Detail, error)
+		DeleteRun func(ctx context.Context, runId string) error
+		Retry     func(ctx context.Context, runId string) error
 	}
 	Calls struct {
-		PostData           []PostDataArgs
-		PutTagsForData     []PutTagsForDataArgs
-		GetDataRaw         []string
-		GetData            []string
-		FindData           []FindDataArgs
+		PostData       []PostDataArgs
+		PutTagsForData []PutTagsForDataArgs
+		GetDataRaw     []string
+		GetData        []string
+		FindData       []FindDataArgs
+
 		GetPlans           []string
 		Findplan           []FindPlanArgs
 		PutPlanForActivate []string
@@ -133,9 +142,11 @@ type mockKnitClient struct {
 			PlanId    string
 			Resources plans.ResourceLimitChange
 		}
-		RegisterPlan []plans.PlanSpec
-		GetRun       []string
-		GetRunLog    []struct {
+		UpdateAnnotations []UpdateAnnotationsArgs
+		RegisterPlan      []plans.PlanSpec
+
+		GetRun    []string
+		GetRunLog []struct {
 			RunId  string
 			Follow bool
 		}
@@ -261,6 +272,16 @@ func (m *mockKnitClient) UpdateResources(ctx context.Context, runId string, reso
 		m.t.Fatal("UpdateResources is not ready to be called")
 	}
 	return m.Impl.UpdateResources(ctx, runId, resources)
+}
+
+func (m *mockKnitClient) UpdateAnnotations(ctx context.Context, planId string, annotations plans.AnnotationChange) (plans.Detail, error) {
+	m.t.Helper()
+
+	m.Calls.UpdateAnnotations = append(m.Calls.UpdateAnnotations, UpdateAnnotationsArgs{PlanId: planId, Annotations: annotations})
+	if m.Impl.UpdateAnnotations == nil {
+		m.t.Fatal("UpdateAnnotations is not ready to be called")
+	}
+	return m.Impl.UpdateAnnotations(ctx, planId, annotations)
 }
 
 func (m *mockKnitClient) GetRun(ctx context.Context, runId string) (runs.Detail, error) {

--- a/cmd/knit/subcommands/plan/annotate/command.go
+++ b/cmd/knit/subcommands/plan/annotate/command.go
@@ -1,0 +1,131 @@
+package annotate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/opst/knitfab-api-types/plans"
+	"github.com/opst/knitfab/cmd/knit/env"
+	"github.com/opst/knitfab/cmd/knit/rest"
+	"github.com/opst/knitfab/cmd/knit/subcommands/common"
+	"github.com/opst/knitfab/pkg/utils"
+	"github.com/youta-t/flarc"
+)
+
+type Annotation plans.Annotation
+
+func (an *Annotation) Set(value string) error {
+	k, v, ok := strings.Cut(value, "=")
+	if !ok {
+		return fmt.Errorf("invalid annotation: %s", value)
+	}
+	*an = Annotation(plans.Annotation{
+		Key:   strings.TrimSpace(k),
+		Value: strings.TrimSpace(v),
+	})
+	return nil
+}
+
+func (an *Annotation) String() string {
+	return fmt.Sprintf("%s=%s", an.Key, an.Value)
+}
+
+type Flag struct {
+	Add    []string `flag:"add" help:"Add an annotation in the form key=value. repeatable."`
+	Remove []string `flag:"remove" help:"Remove an annotation in the form key=value. repeatable."`
+}
+
+const ARGS_PLAN_ID = "PLAN_ID"
+
+func New() (flarc.Command, error) {
+	return flarc.NewCommand(
+		"add or remove annotations on a plan",
+		Flag{},
+		flarc.Args{
+			{
+				Name: ARGS_PLAN_ID, Required: true,
+				Help: "Specify the id of the Plan to be updated its annotations.",
+			},
+		},
+		common.NewTask(Task()),
+		flarc.WithDescription(`
+Add and/or remove annotations on a Plan.
+
+Annotations are key=value pairs that can be used to put metadata to a Plan.
+Annotations are not used by Knitfab itself, but can be used by other tools or users.
+
+To add,
+
+    {{ .Command }} --add key1=value1 --add key2=value2
+
+To remove,
+
+    {{ .Command }} --remove key1=value1 --remove key2=value2
+
+On remove, the key AND value must match the annotation to be removed.
+
+Flags --add and --remove can be passed at once.
+If do so, Knitfab applies "remove" first, then "add" (= addition take precedence).
+`),
+	)
+}
+
+func Task() common.Task[Flag] {
+	return func(
+		ctx context.Context,
+		logger *log.Logger,
+		knitEnv env.KnitEnv,
+		client rest.KnitClient,
+		cl flarc.Commandline[Flag],
+		params []any,
+	) error {
+		args := cl.Args()
+		planId := args[ARGS_PLAN_ID][0]
+
+		flags := cl.Flags()
+
+		parseAnnotation := func(s string) (plans.Annotation, error) {
+			k, v, ok := strings.Cut(s, "=")
+			if !ok {
+				return plans.Annotation{}, fmt.Errorf("invalid annotation: %s", s)
+			}
+			return plans.Annotation{
+				Key:   strings.TrimSpace(k),
+				Value: strings.TrimSpace(v),
+			}, nil
+		}
+
+		add, err := utils.MapUntilError(flags.Add, parseAnnotation)
+		if err != nil {
+			return errors.Join(flarc.ErrUsage, err)
+		}
+
+		remove, err := utils.MapUntilError(flags.Remove, parseAnnotation)
+		if err != nil {
+			return errors.Join(flarc.ErrUsage, err)
+		}
+
+		change := plans.AnnotationChange{
+			Add:    plans.Annotations(add),
+			Remove: plans.Annotations(remove),
+		}
+
+		pln, err := client.UpdateAnnotations(ctx, planId, change)
+		if err != nil {
+			return err
+		}
+
+		logger.Printf("Plan:%s is updated.\n", pln.PlanId)
+
+		enc := json.NewEncoder(cl.Stdout())
+		enc.SetIndent("", "    ")
+		if err := enc.Encode(pln); err != nil {
+			return err
+		}
+		return nil
+	}
+}

--- a/cmd/knit/subcommands/plan/annotate/command_test.go
+++ b/cmd/knit/subcommands/plan/annotate/command_test.go
@@ -1,0 +1,186 @@
+package annotate_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/opst/knitfab-api-types/plans"
+	"github.com/opst/knitfab-api-types/tags"
+	"github.com/opst/knitfab/cmd/knit/env"
+	"github.com/opst/knitfab/cmd/knit/rest/mock"
+	"github.com/opst/knitfab/cmd/knit/subcommands/internal/commandline"
+	"github.com/opst/knitfab/cmd/knit/subcommands/logger"
+	"github.com/opst/knitfab/cmd/knit/subcommands/plan/annotate"
+	"github.com/opst/knitfab/pkg/cmp"
+)
+
+func TestCommand(t *testing.T) {
+	type When struct {
+		Flag annotate.Flag
+		Args map[string][]string
+
+		UpdateAnnotationsReturn plans.Detail
+		UpdateAnnotationsError  error
+	}
+
+	type Then struct {
+		UpdateAnnotationsArgsPlanId string
+		UpdateAnnotationsArgsChange plans.AnnotationChange
+
+		Err error
+	}
+
+	theory := func(when When, then Then) func(*testing.T) {
+		return func(t *testing.T) {
+			ctx := context.Background()
+			logger := logger.Null()
+			e := env.New()
+
+			stdout := new(strings.Builder)
+			stderr := new(strings.Builder)
+
+			cl := commandline.MockCommandline[annotate.Flag]{
+				Fullname_: "annotate",
+				Flags_:    when.Flag,
+				Args_:     when.Args,
+				Stdin_:    nil, // not used
+				Stdout_:   stdout,
+				Stderr_:   stderr,
+			}
+
+			client := mock.New(t)
+			client.Impl.UpdateAnnotations = func(
+				ctx context.Context,
+				planId string,
+				change plans.AnnotationChange,
+			) (plans.Detail, error) {
+				if planId != then.UpdateAnnotationsArgsPlanId {
+					t.Errorf(
+						"planId in request:\n===actual===\n%v\n===expected===\n%v",
+						planId, then.UpdateAnnotationsArgsPlanId,
+					)
+				}
+
+				if !cmp.SliceContentEq(change.Add, then.UpdateAnnotationsArgsChange.Add) {
+					t.Errorf(
+						"change.Add in request:\n===actual===\n%v\n===expected===\n%v",
+						change.Add, then.UpdateAnnotationsArgsChange.Add,
+					)
+				}
+
+				if !cmp.SliceContentEq(change.Remove, then.UpdateAnnotationsArgsChange.Remove) {
+					t.Errorf(
+						"change.Remove in request:\n===actual===\n%v\n===expected===\n%v",
+						change.Remove, then.UpdateAnnotationsArgsChange.Remove,
+					)
+				}
+
+				return when.UpdateAnnotationsReturn, when.UpdateAnnotationsError
+			}
+
+			err := annotate.Task()(ctx, logger, *e, client, cl, []any{})
+			if err != nil {
+				if then.Err == nil {
+					t.Fatalf("unexpected error: %+v", err)
+				} else if !errors.Is(err, then.Err) {
+					t.Errorf("returned error is not expected one: %+v", err)
+				}
+				return
+			} else if then.Err != nil {
+				t.Fatalf("expected error but got nil")
+			}
+
+			var actual plans.Detail
+			if err := json.Unmarshal([]byte(stdout.String()), &actual); err != nil {
+				t.Fatalf("failed to decode stdout: %v", err)
+			}
+			if !actual.Equal(when.UpdateAnnotationsReturn) {
+				t.Errorf(
+					"response\n===actual===\n%+v\n===expected===\n%+v",
+					actual, when.UpdateAnnotationsReturn,
+				)
+			}
+		}
+	}
+
+	t.Run("when client return plan detail, it return that detail", theory(
+		When{
+			Flag: annotate.Flag{
+				Add:    []string{"key1=value1", "key2=value2"},
+				Remove: []string{"key3=value3", "key4=value4"},
+			},
+			Args: map[string][]string{annotate.ARGS_PLAN_ID: {"test-plan-id"}},
+			UpdateAnnotationsReturn: plans.Detail{
+				Summary: plans.Summary{
+					PlanId: "test-plan-id",
+					Image:  &plans.Image{Repository: "repo.invalid/test-image", Tag: "test-version"},
+					Annotations: plans.Annotations{
+						{Key: "key1", Value: "value1"},
+						{Key: "key2", Value: "value2"},
+					},
+				},
+				Active: true,
+				Inputs: []plans.Mountpoint{
+					{
+						Path: "/in/1",
+						Tags: []tags.Tag{
+							{Key: "type", Value: "raw data"},
+							{Key: "format", Value: "rgb image"},
+						},
+					},
+				},
+				Outputs: []plans.Mountpoint{
+					{
+						Path: "/out/2",
+						Tags: []tags.Tag{
+							{Key: "type", Value: "training data"},
+							{Key: "format", Value: "mask"},
+						},
+					},
+				},
+				Log: &plans.LogPoint{
+					Tags: []tags.Tag{
+						{Key: "type", Value: "log"},
+						{Key: "format", Value: "jsonl"},
+					},
+				},
+			},
+			UpdateAnnotationsError: nil,
+		},
+		Then{
+			UpdateAnnotationsArgsPlanId: "test-plan-id",
+
+			UpdateAnnotationsArgsChange: plans.AnnotationChange{
+				Add:    plans.Annotations{{Key: "key1", Value: "value1"}, {Key: "key2", Value: "value2"}},
+				Remove: plans.Annotations{{Key: "key3", Value: "value3"}, {Key: "key4", Value: "value4"}},
+			},
+		},
+	))
+
+	{
+		wantErr := errors.New("test-error")
+		t.Run("when client return error, it return that error", theory(
+			When{
+				Flag: annotate.Flag{
+					Add:    []string{"key1=value1", "key2=value2"},
+					Remove: []string{"key3=value3", "key4=value4"},
+				},
+				Args:                    map[string][]string{annotate.ARGS_PLAN_ID: {"test-plan-id"}},
+				UpdateAnnotationsReturn: plans.Detail{},
+				UpdateAnnotationsError:  wantErr,
+			},
+			Then{
+				UpdateAnnotationsArgsPlanId: "test-plan-id",
+
+				UpdateAnnotationsArgsChange: plans.AnnotationChange{
+					Add:    plans.Annotations{{Key: "key1", Value: "value1"}, {Key: "key2", Value: "value2"}},
+					Remove: plans.Annotations{{Key: "key3", Value: "value3"}, {Key: "key4", Value: "value4"}},
+				},
+				Err: wantErr,
+			},
+		))
+	}
+}

--- a/cmd/knit/subcommands/plan/command.go
+++ b/cmd/knit/subcommands/plan/command.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	plan_active "github.com/opst/knitfab/cmd/knit/subcommands/plan/active"
+	plan_annotate "github.com/opst/knitfab/cmd/knit/subcommands/plan/annotate"
 	plan_apply "github.com/opst/knitfab/cmd/knit/subcommands/plan/apply"
 	plan_find "github.com/opst/knitfab/cmd/knit/subcommands/plan/find"
 
@@ -43,6 +44,11 @@ func New() (flarc.Command, error) {
 		return nil, err
 	}
 
+	annotate, err := plan_annotate.New()
+	if err != nil {
+		return nil, err
+	}
+
 	return flarc.NewCommandGroup(
 		"Manipulate Knitfab Plan.",
 		struct{}{},
@@ -52,6 +58,7 @@ func New() (flarc.Command, error) {
 		flarc.WithSubcommand("apply", apply),
 		flarc.WithSubcommand("active", active),
 		flarc.WithSubcommand("resource", resource),
+		flarc.WithSubcommand("annotate", annotate),
 	)
 
 }

--- a/cmd/knitd/main.go
+++ b/cmd/knitd/main.go
@@ -142,6 +142,7 @@ func main() {
 		e.PUT(api("plans/:planId/active"), handlers.PutPlanForActivate(db.Plan(), true))
 		e.DELETE(api("plans/:planId/active"), handlers.PutPlanForActivate(db.Plan(), false))
 		e.PUT(api("plans/:planId/resources"), handlers.PutPlanResource(db.Plan(), "planId"))
+		e.PUT(api("plans/:planId/annotations"), handlers.PutPlanAnnotations(db.Plan(), "planId"))
 	}
 
 	{

--- a/pkg/db/plan.go
+++ b/pkg/db/plan.go
@@ -137,11 +137,41 @@ type PlanInterface interface {
 	//
 	// - error
 	Find(context.Context, logic.Ternary, ImageIdentifier, []Tag, []Tag) ([]string, error)
+
+	// UpdateAnnotations updates Annotations of a Plan.
+	//
+	// Args
+	//
+	// - context.Context
+	//
+	// - string : Plan ID
+	//
+	// - AnnotationDelta : Annotations to be added and removed
+	//
+	// Returns
+	//
+	// - error
+	UpdateAnnotations(context.Context, string, AnnotationDelta) error
 }
 
 type Annotation struct {
 	Key   string
 	Value string
+}
+
+// AnnotationDelta is a struct that represents the changesets of annotations.
+//
+// Remove is applied first, and then Add is applied.
+type AnnotationDelta struct {
+	// Add is a list of annotations to be added.
+	//
+	// If Plan already has an annotation in Add, it will be ignored.
+	Add []Annotation
+
+	// Remove is a list of annotations to be removed.
+	//
+	// If Plan does not have an annotation in Remove, it will be ignored.
+	Remove []Annotation
 }
 
 // Main body of plan, describes "what it is".

--- a/pkg/db/postgres/plan/plan.go
+++ b/pkg/db/postgres/plan/plan.go
@@ -1025,3 +1025,105 @@ func (m *planPG) find(
 
 	return planIds, nil
 }
+
+func (m *planPG) UpdateAnnotations(ctx context.Context, planId string, delta kdb.AnnotationDelta) error {
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	{ // check plan existence
+		found := 0
+		if err := tx.QueryRow(
+			ctx,
+			`
+with "plan" as (
+	select "plan_id" from "plan" where "plan_id" = $1 for key share
+)
+select count("plan_id") from "plan"
+`,
+			planId,
+		).Scan(&found); err != nil {
+			return err
+		}
+
+		if found <= 0 {
+			return kpgerr.Missing{
+				Table:    "plan",
+				Identity: fmt.Sprintf("plan_id='%s'", planId),
+			}
+		}
+	}
+
+	if remove := delta.Remove; 0 < len(remove) {
+		keys := make([]string, len(remove))
+		values := make([]string, len(remove))
+
+		for i, anno := range remove {
+			keys[i] = anno.Key
+			values[i] = anno.Value
+		}
+
+		if _, err := tx.Exec(
+			ctx,
+			`
+with "plan" as (
+	select "plan_id" from "plan" where "plan_id" = $1
+),
+"_rem" as (
+	select unnest($2::varchar[]) as "key", unnest($3::varchar[]) as "value"
+),
+"rem" as (
+	select "plan_id", "key", "value"
+	from "plan"
+	left join (table "_rem") as "t" on true
+)
+delete from "plan_annotation"
+where ("plan_id", "key", "value") = any(select "plan_id", "key", "value" from "rem")
+`,
+			planId, keys, values,
+		); err != nil {
+			return err
+		}
+	}
+
+	if add := delta.Add; 0 < len(add) {
+		keys := make([]string, len(add))
+		values := make([]string, len(add))
+
+		for i, anno := range add {
+			keys[i] = anno.Key
+			values[i] = anno.Value
+		}
+
+		if _, err := tx.Exec(
+			ctx,
+			`
+with "plan" as (
+	select "plan_id" from "plan" where "plan_id" = $1
+),
+"_add" as (
+	select unnest($2::varchar[]) as "key", unnest($3::varchar[]) as "value"
+),
+"add" as (
+	select "plan_id", "key", "value"
+	from "plan"
+	left join (table "_add") as "t" on true
+)
+insert into "plan_annotation" ("plan_id", "key", "value")
+select distinct "plan_id", "key", "value"
+from "add"
+on conflict do nothing
+`,
+			planId, keys, values,
+		); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
##  About this PR

- add new WebAPI `PUT /api/plans/:planId/annotations`
- add new CLI Subcommand `knit plan annotate`

## Related issue

close #184 