### PR TITLE
Plan: serviceaccount is mutable

### DIFF
--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -231,6 +231,40 @@ type KnitClient interface {
 	//
 	UpdateAnnotations(ctx context.Context, planId string, change plans.AnnotationChange) (plans.Detail, error)
 
+	// SetServiceAccount set service account of plan with given planId.
+	//
+	// Args
+	//
+	// - context.Context
+	//
+	// - string: planId to be updated
+	//
+	// - string: service account to be set
+	//
+	// Returns
+	//
+	// - apiplans.Detail: metadata of updated plan
+	//
+	// - error
+	//
+	SetServiceAccount(ctx context.Context, planId string, serviceAccount plans.SetServiceAccount) (plans.Detail, error)
+
+	// UnsetServiceAccount unset service account of plan with given planId.
+	//
+	// Args
+	//
+	// - context.Context
+	//
+	// - string: planId to be updated
+	//
+	// Returns
+	//
+	// - apiplans.Detail: metadata of updated plan
+	//
+	// - error
+	//
+	UnsetServiceAccount(ctx context.Context, planId string) (plans.Detail, error)
+
 	// GetRun get run detail with given runId.
 	//
 	// Args

--- a/cmd/knit/rest/plan.go
+++ b/cmd/knit/rest/plan.go
@@ -212,3 +212,59 @@ func (c *client) UpdateAnnotations(ctx context.Context, planId string, change pl
 	}
 	return dataMetas, nil
 }
+
+func (c *client) SetServiceAccount(ctx context.Context, planId string, setServiceAccount plans.SetServiceAccount) (plans.Detail, error) {
+	b, err := json.Marshal(setServiceAccount)
+	if err != nil {
+		return plans.Detail{}, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, c.apipath("plans", planId, "serviceaccount"), bytes.NewBuffer(b))
+	if err != nil {
+		return plans.Detail{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpclient.Do(req)
+	if err != nil {
+		return plans.Detail{}, err
+	}
+	defer resp.Body.Close()
+
+	var dataMetas plans.Detail
+	if err := unmarshalJsonResponse(
+		resp, &dataMetas,
+		MessageFor{
+			Status4xx: fmt.Sprintf("planId:%v cannot be updated", planId),
+			Status5xx: fmt.Sprintf("server error (status code = %d)", resp.StatusCode),
+		},
+	); err != nil {
+		return plans.Detail{}, err
+	}
+	return dataMetas, nil
+}
+
+func (c *client) UnsetServiceAccount(ctx context.Context, planId string) (plans.Detail, error) {
+	req, err := http.NewRequest(http.MethodDelete, c.apipath("plans", planId, "serviceaccount"), nil)
+	if err != nil {
+		return plans.Detail{}, err
+	}
+
+	resp, err := c.httpclient.Do(req)
+	if err != nil {
+		return plans.Detail{}, err
+	}
+	defer resp.Body.Close()
+
+	var dataMetas plans.Detail
+	if err := unmarshalJsonResponse(
+		resp, &dataMetas,
+		MessageFor{
+			Status4xx: fmt.Sprintf("planId:%v cannot be updated", planId),
+			Status5xx: fmt.Sprintf("server error (status code = %d)", resp.StatusCode),
+		},
+	); err != nil {
+		return plans.Detail{}, err
+	}
+	return dataMetas, nil
+}

--- a/cmd/knit/rest/plan_test.go
+++ b/cmd/knit/rest/plan_test.go
@@ -1040,3 +1040,297 @@ func TestUpdateAnnotations(t *testing.T) {
 		}))
 	})
 }
+
+func TestSetServiceAccount_success_case(t *testing.T) {
+	type When struct {
+		planId             string
+		sa                 plans.SetServiceAccount
+		requestContentType string
+
+		response plans.Detail
+	}
+
+	theory := func(when When) func(t *testing.T) {
+		return func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Content-Type") != when.requestContentType {
+					t.Errorf("request is not %s. actual content-type = %s", when.requestContentType, r.Header.Get("Content-Type"))
+				}
+
+				got := new(plans.SetServiceAccount)
+				if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+					t.Fatal(err)
+				}
+
+				if *got != when.sa {
+					t.Errorf("request is wrong: actual = %v, expected = %v", got, when.sa)
+				}
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				body := try.To(json.Marshal(when.response)).OrFatal(t)
+				w.Write(body)
+			}))
+
+			defer server.Close()
+
+			profile := kprof.KnitProfile{ApiRoot: server.URL}
+
+			testee := try.To(krst.NewClient(&profile)).OrFatal(t)
+
+			ctx := context.Background()
+			actualResponse := try.To(testee.SetServiceAccount(ctx, when.planId, when.sa)).OrFatal(t)
+
+			if !actualResponse.Equal(when.response) {
+				t.Errorf("response is not equal (actual,expected): %+v\n%+v", actualResponse, when.response)
+			}
+		}
+	}
+
+	t.Run("when server returns data, it returns that as is", theory(When{
+		planId: "test-Id",
+		sa: plans.SetServiceAccount{
+			ServiceAccount: "test-service-account",
+		},
+		requestContentType: "application/json",
+		response: plans.Detail{
+			Summary: plans.Summary{
+				PlanId: "test-Id",
+				Image: &plans.Image{
+					Repository: "test-image", Tag: "test-version",
+				},
+				Name: "test-Name",
+			},
+			Inputs: []plans.Mountpoint{
+				{
+					Path: "/in/1",
+					Tags: []tags.Tag{
+						{Key: "type", Value: "raw data"},
+						{Key: "format", Value: "rgb image"},
+					},
+				},
+			},
+			Outputs: []plans.Mountpoint{
+				{
+					Path: "/out/2",
+					Tags: []tags.Tag{
+						{Key: "type", Value: "training data"},
+						{Key: "format", Value: "mask"},
+					},
+				},
+			},
+			Log: &plans.LogPoint{
+				Tags: []tags.Tag{
+					{Key: "type", Value: "log"},
+					{Key: "format", Value: "jsonl"},
+				},
+			},
+			Active:         true,
+			ServiceAccount: "test-service-account",
+		},
+	}))
+}
+
+func TestSetServiceAccount_error_case(t *testing.T) {
+	type When struct {
+		planId string
+		sa     plans.SetServiceAccount
+
+		statusCode int
+	}
+
+	theory := func(when When) func(t *testing.T) {
+		return func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Errorf("request is not application/json. actual content-type = %s", r.Header.Get("Content-Type"))
+				}
+
+				got := new(plans.SetServiceAccount)
+				if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+					t.Fatal(err)
+				}
+
+				if *got != when.sa {
+					t.Errorf("request is wrong: actual = %v, expected = %v", got, when.sa)
+				}
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(when.statusCode)
+			}))
+
+			defer server.Close()
+
+			profile := kprof.KnitProfile{ApiRoot: server.URL}
+
+			testee := try.To(krst.NewClient(&profile)).OrFatal(t)
+
+			ctx := context.Background()
+			_, err := testee.SetServiceAccount(ctx, when.planId, when.sa)
+
+			if err == nil {
+				t.Error("no error occured")
+			}
+		}
+	}
+
+	t.Run(": 4xx error", theory(When{
+		planId: "test-Id",
+		sa: plans.SetServiceAccount{
+			ServiceAccount: "test-service-account",
+		},
+		statusCode: http.StatusBadRequest,
+	}))
+
+	t.Run(": 5xx error", theory(When{
+		planId: "test-Id",
+		sa: plans.SetServiceAccount{
+			ServiceAccount: "test-service-account",
+		},
+		statusCode: http.StatusInternalServerError,
+	}))
+}
+
+func TestUnsetServiceAccount_success_case(t *testing.T) {
+	type When struct {
+		planId string
+
+		response plans.Detail
+	}
+
+	theory := func(when When) func(t *testing.T) {
+		return func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf(
+						"request is not DELETE: actual method = %s",
+						r.Method,
+					)
+				}
+
+				if !strings.HasSuffix(r.URL.Path, "/plans/"+when.planId+"/serviceaccount") {
+					t.Errorf(
+						"request is not /plans/:planId/service_account. actual path = %s",
+						r.URL.Path,
+					)
+				}
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				body := try.To(json.Marshal(when.response)).OrFatal(t)
+				w.Write(body)
+			}))
+
+			defer server.Close()
+
+			profile := kprof.KnitProfile{ApiRoot: server.URL}
+
+			testee := try.To(krst.NewClient(&profile)).OrFatal(t)
+
+			ctx := context.Background()
+			got, err := testee.UnsetServiceAccount(ctx, when.planId)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !got.Equal(when.response) {
+				t.Errorf(
+					"response is not equal (actual,expected): %+v\n%+v",
+					got, when.response,
+				)
+			}
+		}
+	}
+
+	t.Run("when server returns data, it returns that as is", theory(When{
+		planId: "test-Id",
+		response: plans.Detail{
+			Summary: plans.Summary{
+				PlanId: "test-id",
+				Image: &plans.Image{
+					Repository: "test-image", Tag: "test-version",
+				},
+				Name: "test-Name",
+			},
+			Inputs: []plans.Mountpoint{
+				{
+					Path: "/in/1",
+					Tags: []tags.Tag{
+						{Key: "type", Value: "raw data"},
+						{Key: "format", Value: "rgb image"},
+					},
+				},
+			},
+			Outputs: []plans.Mountpoint{
+				{
+					Path: "/out/2",
+					Tags: []tags.Tag{
+						{Key: "type", Value: "training data"},
+						{Key: "format", Value: "mask"},
+					},
+				},
+			},
+			Log: &plans.LogPoint{
+				Tags: []tags.Tag{
+					{Key: "type", Value: "log"},
+					{Key: "format", Value: "jsonl"},
+				},
+			},
+			Active: true,
+		},
+	}))
+}
+
+func TestUnsetServiceAccount_error_case(t *testing.T) {
+	type When struct {
+		planId string
+
+		statusCode int
+	}
+
+	theory := func(when When) func(t *testing.T) {
+		return func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf(
+						"request is not DELETE: actual method = %s",
+						r.Method,
+					)
+				}
+
+				if !strings.HasSuffix(r.URL.Path, "/plans/"+when.planId+"/serviceaccount") {
+					t.Errorf(
+						"request is not /plans/:planId/service_account. actual path = %s",
+						r.URL.Path,
+					)
+				}
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(when.statusCode)
+			}))
+
+			defer server.Close()
+
+			profile := kprof.KnitProfile{ApiRoot: server.URL}
+
+			testee := try.To(krst.NewClient(&profile)).OrFatal(t)
+
+			ctx := context.Background()
+			_, err := testee.UnsetServiceAccount(ctx, when.planId)
+
+			if err == nil {
+				t.Error("no error occured")
+			}
+		}
+	}
+
+	t.Run(": 4xx error", theory(When{
+		planId:     "test-Id",
+		statusCode: http.StatusBadRequest,
+	}))
+
+	t.Run(": 5xx error", theory(When{
+		planId:     "test-Id",
+		statusCode: http.StatusInternalServerError,
+	}))
+}

--- a/cmd/knit/subcommands/plan/command.go
+++ b/cmd/knit/subcommands/plan/command.go
@@ -5,8 +5,8 @@ import (
 	plan_annotate "github.com/opst/knitfab/cmd/knit/subcommands/plan/annotate"
 	plan_apply "github.com/opst/knitfab/cmd/knit/subcommands/plan/apply"
 	plan_find "github.com/opst/knitfab/cmd/knit/subcommands/plan/find"
-
 	plan_resource "github.com/opst/knitfab/cmd/knit/subcommands/plan/resource"
+	plan_serviceaccount "github.com/opst/knitfab/cmd/knit/subcommands/plan/serviceaccount"
 	plan_show "github.com/opst/knitfab/cmd/knit/subcommands/plan/show"
 	plan_template "github.com/opst/knitfab/cmd/knit/subcommands/plan/template"
 	"github.com/youta-t/flarc"
@@ -49,6 +49,11 @@ func New() (flarc.Command, error) {
 		return nil, err
 	}
 
+	serviceaccount, err := plan_serviceaccount.New()
+	if err != nil {
+		return nil, err
+	}
+
 	return flarc.NewCommandGroup(
 		"Manipulate Knitfab Plan.",
 		struct{}{},
@@ -59,6 +64,7 @@ func New() (flarc.Command, error) {
 		flarc.WithSubcommand("active", active),
 		flarc.WithSubcommand("resource", resource),
 		flarc.WithSubcommand("annotate", annotate),
+		flarc.WithSubcommand("serviceaccount", serviceaccount),
 	)
 
 }

--- a/cmd/knit/subcommands/plan/serviceaccount/command.go
+++ b/cmd/knit/subcommands/plan/serviceaccount/command.go
@@ -1,0 +1,88 @@
+package serviceaccount
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/opst/knitfab-api-types/plans"
+	"github.com/opst/knitfab/cmd/knit/env"
+	"github.com/opst/knitfab/cmd/knit/rest"
+	"github.com/opst/knitfab/cmd/knit/subcommands/common"
+	"github.com/youta-t/flarc"
+)
+
+type Flag struct {
+	Set   string `flag:"set" help:"Set the service account name. Exclusive with --unset."`
+	Unset bool   `flag:"unset" help:"Unset the service account name. Exclusive with --set."`
+}
+
+const ARGS_PLAN_ID = "PLAN_ID"
+
+func New() (flarc.Command, error) {
+	return flarc.NewCommand(
+		"set or unset the service account name on a plan",
+		Flag{},
+		flarc.Args{
+			{
+				Name: ARGS_PLAN_ID, Required: true,
+				Help: "Specify the id of the Plan to be updated its service account name.",
+			},
+		},
+		common.NewTask(Task()),
+		flarc.WithDescription(`
+Set or unset the service account name on a Plan.
+
+The specified service account name will be used to execute Runs of the Plan.
+
+For service accounts which can be used, ask your Knitfab administrator.
+`),
+	)
+}
+
+func Task() common.Task[Flag] {
+	return func(
+		ctx context.Context,
+		logger *log.Logger,
+		knitEnv env.KnitEnv,
+		client rest.KnitClient,
+		cl flarc.Commandline[Flag],
+		params []any,
+	) error {
+		planId := cl.Args()[ARGS_PLAN_ID][0]
+
+		if cl.Flags().Set != "" && cl.Flags().Unset {
+			return fmt.Errorf("%w: cannot use --set and --unset at once", flarc.ErrUsage)
+		}
+
+		var resp plans.Detail
+		if cl.Flags().Set != "" {
+			_r, err := client.SetServiceAccount(
+				ctx, planId, plans.SetServiceAccount{ServiceAccount: cl.Flags().Set},
+			)
+			if err != nil {
+				return err
+			}
+			resp = _r
+			logger.Printf("Plan %s: serviceaccount is set", planId)
+		} else if cl.Flags().Unset {
+			_r, err := client.UnsetServiceAccount(ctx, planId)
+			if err != nil {
+				return err
+			}
+			resp = _r
+			logger.Printf("Plan %s: serviceaccount is unset", planId)
+		} else {
+			return fmt.Errorf("%w: either --set or --unset is required", flarc.ErrUsage)
+		}
+
+		j := json.NewEncoder(cl.Stdout())
+		j.SetIndent("", "    ")
+		if err := j.Encode(resp); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/cmd/knit/subcommands/plan/serviceaccount/commnad_test.go
+++ b/cmd/knit/subcommands/plan/serviceaccount/commnad_test.go
@@ -1,0 +1,210 @@
+package serviceaccount_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/opst/knitfab-api-types/plans"
+	"github.com/opst/knitfab/cmd/knit/env"
+	"github.com/opst/knitfab/cmd/knit/rest/mock"
+	"github.com/opst/knitfab/cmd/knit/subcommands/internal/commandline"
+	"github.com/opst/knitfab/cmd/knit/subcommands/logger"
+	"github.com/opst/knitfab/cmd/knit/subcommands/plan/serviceaccount"
+	"github.com/youta-t/flarc"
+)
+
+func TestTask(t *testing.T) {
+	type When struct {
+		Args  map[string][]string
+		Flags serviceaccount.Flag
+
+		Response plans.Detail
+		RespErr  error
+	}
+
+	type Then struct {
+		SetIsCalled bool
+		PlanId      string
+
+		UnsetIsCalled bool
+
+		Err error
+	}
+
+	theory := func(when When, then Then) func(t *testing.T) {
+		return func(t *testing.T) {
+			ctx := context.Background()
+			logger := logger.Null()
+			e := env.New()
+
+			stdout := new(strings.Builder)
+			stderr := new(strings.Builder)
+
+			cl := commandline.MockCommandline[serviceaccount.Flag]{
+				Fullname_: "annotate",
+				Flags_:    when.Flags,
+				Args_:     when.Args,
+				Stdin_:    nil, // not used
+				Stdout_:   stdout,
+				Stderr_:   stderr,
+			}
+
+			client := mock.New(t)
+			client.Impl.SetServiceAccount = func(ctx context.Context, planId string, setServiceAccount plans.SetServiceAccount) (plans.Detail, error) {
+				then.SetIsCalled = true
+
+				if planId != then.PlanId {
+					t.Errorf("planId: got %v, want %v", planId, then.PlanId)
+				}
+
+				if setServiceAccount.ServiceAccount != when.Flags.Set {
+					t.Errorf("setServiceAccount.Name: got %v, want %v", setServiceAccount.ServiceAccount, when.Flags.Set)
+				}
+
+				return when.Response, when.RespErr
+			}
+
+			client.Impl.UnsetServiceAccount = func(ctx context.Context, planId string) (plans.Detail, error) {
+				then.UnsetIsCalled = true
+
+				if planId != then.PlanId {
+					t.Errorf("planId: got %v, want %v", planId, then.PlanId)
+				}
+
+				return when.Response, when.RespErr
+			}
+
+			err := serviceaccount.Task()(
+				ctx, logger, *e, client, cl, []interface{}{},
+			)
+			if err != nil {
+				if then.Err == nil {
+					t.Errorf("unexpected error: %v", err)
+				} else if !errors.Is(err, then.Err) {
+					t.Errorf("expected error: %v, got: %v", then.Err, err)
+				}
+				return
+			}
+
+			if then.Err != nil {
+				t.Errorf("error is expected, but not got: %v", then.Err)
+			}
+
+			got := new(plans.Detail)
+			if err := json.Unmarshal([]byte(stdout.String()), got); err != nil {
+				t.Errorf("failed to unmarshal stdout: %v", err)
+			}
+
+			if !got.Equal(when.Response) {
+				t.Errorf("response: got %v, want %v", got, when.Response)
+			}
+		}
+	}
+
+	t.Run("set", theory(
+		When{
+			Args:  map[string][]string{"PLAN_ID": {"plan-1"}},
+			Flags: serviceaccount.Flag{Set: "service-account-1"},
+			Response: plans.Detail{
+				Summary:        plans.Summary{PlanId: "plan-1"},
+				ServiceAccount: "service-account-1",
+			},
+			RespErr: nil,
+		},
+		Then{
+			SetIsCalled: true,
+			PlanId:      "plan-1",
+			Err:         nil,
+		},
+	))
+
+	t.Run("unset", theory(
+		When{
+			Args:  map[string][]string{"PLAN_ID": {"plan-1"}},
+			Flags: serviceaccount.Flag{Unset: true},
+			Response: plans.Detail{
+				Summary: plans.Summary{PlanId: "plan-1"},
+			},
+			RespErr: nil,
+		},
+		Then{
+			UnsetIsCalled: true,
+			PlanId:        "plan-1",
+			Err:           nil,
+		},
+	))
+
+	t.Run("set and unset (should be error)", theory(
+		When{
+			Args:  map[string][]string{"PLAN_ID": {"plan-1"}},
+			Flags: serviceaccount.Flag{Set: "service-account-1", Unset: true},
+			Response: plans.Detail{
+				Summary: plans.Summary{PlanId: "plan-1"},
+			},
+			RespErr: nil,
+		},
+		Then{
+			SetIsCalled:   false,
+			UnsetIsCalled: false,
+			Err:           flarc.ErrUsage,
+		},
+	))
+
+	t.Run("neither set not unset (should be error)", theory(
+		When{
+			Args:  map[string][]string{"PLAN_ID": {"plan-1"}},
+			Flags: serviceaccount.Flag{},
+			Response: plans.Detail{
+				Summary: plans.Summary{PlanId: "plan-1"},
+			},
+			RespErr: nil,
+		},
+		Then{
+			SetIsCalled:   false,
+			UnsetIsCalled: false,
+			Err:           flarc.ErrUsage,
+		},
+	))
+
+	{
+		wantErr := errors.New("test-error")
+		t.Run("client error on set", theory(
+			When{
+				Args:  map[string][]string{"PLAN_ID": {"plan-1"}},
+				Flags: serviceaccount.Flag{Set: "service-account-1"},
+				Response: plans.Detail{
+					Summary:        plans.Summary{PlanId: "plan-1"},
+					ServiceAccount: "service-account-1",
+				},
+				RespErr: wantErr,
+			},
+			Then{
+				SetIsCalled: true,
+				PlanId:      "plan-1",
+				Err:         wantErr,
+			},
+		))
+	}
+
+	{
+		wantErr := errors.New("test-error")
+		t.Run("client error on unset", theory(
+			When{
+				Args:  map[string][]string{"PLAN_ID": {"plan-1"}},
+				Flags: serviceaccount.Flag{Unset: true},
+				Response: plans.Detail{
+					Summary: plans.Summary{PlanId: "plan-1"},
+				},
+				RespErr: wantErr,
+			},
+			Then{
+				UnsetIsCalled: true,
+				PlanId:        "plan-1",
+				Err:           wantErr,
+			},
+		))
+	}
+}

--- a/cmd/knitd/main.go
+++ b/cmd/knitd/main.go
@@ -143,6 +143,8 @@ func main() {
 		e.DELETE(api("plans/:planId/active"), handlers.PutPlanForActivate(db.Plan(), false))
 		e.PUT(api("plans/:planId/resources"), handlers.PutPlanResource(db.Plan(), "planId"))
 		e.PUT(api("plans/:planId/annotations"), handlers.PutPlanAnnotations(db.Plan(), "planId"))
+		e.PUT(api("plans/:planId/serviceaccount"), handlers.PutPlanServiceAccount(db.Plan(), "planId"))
+		e.DELETE(api("plans/:planId/serviceaccount"), handlers.DeletePlanServiceAccount(db.Plan(), "planId"))
 	}
 
 	{

--- a/pkg/db/mocks/plan.go
+++ b/pkg/db/mocks/plan.go
@@ -35,22 +35,31 @@ type UpdateAnnotationsArgs struct {
 	Delta  kdb.AnnotationDelta
 }
 
+type SetServiceAccountArgs struct {
+	PlanId         string
+	ServiceAccount string
+}
+
 type PlanInterface struct {
 	Impl struct {
-		Get                func(context.Context, []string) (map[string]*kdb.Plan, error)
-		Register           func(context.Context, *kdb.PlanSpec) (string, error)
-		Activate           func(context.Context, string, bool) error
-		SetResourceLimit   func(context.Context, string, map[string]resource.Quantity) error
-		UnsetResourceLimit func(context.Context, string, []string) error
-		Find               func(context.Context, logic.Ternary, kdb.ImageIdentifier, []kdb.Tag, []kdb.Tag) ([]string, error)
-		UpdateAnnotations  func(context.Context, string, kdb.AnnotationDelta) error
+		Get                 func(context.Context, []string) (map[string]*kdb.Plan, error)
+		Register            func(context.Context, *kdb.PlanSpec) (string, error)
+		Activate            func(context.Context, string, bool) error
+		SetResourceLimit    func(context.Context, string, map[string]resource.Quantity) error
+		UnsetResourceLimit  func(context.Context, string, []string) error
+		Find                func(context.Context, logic.Ternary, kdb.ImageIdentifier, []kdb.Tag, []kdb.Tag) ([]string, error)
+		UpdateAnnotations   func(context.Context, string, kdb.AnnotationDelta) error
+		SetServiceAccount   func(context.Context, string, string) error
+		UnsetServiceAccount func(context.Context, string) error
 	}
 	Calls struct {
-		Get               CallLog[[]string]
-		Register          CallLog[*kdb.PlanSpec]
-		Activate          CallLog[string]
-		Find              CallLog[PlanFindArgs]
-		UpdateAnnotations CallLog[UpdateAnnotationsArgs]
+		Get                 CallLog[[]string]
+		Register            CallLog[*kdb.PlanSpec]
+		Activate            CallLog[string]
+		Find                CallLog[PlanFindArgs]
+		UpdateAnnotations   CallLog[UpdateAnnotationsArgs]
+		SetServiceAccount   CallLog[SetServiceAccountArgs]
+		UnsetServiceAccount CallLog[string]
 	}
 }
 
@@ -127,6 +136,27 @@ func (m *PlanInterface) UpdateAnnotations(ctx context.Context, planId string, an
 	})
 	if m.Impl.UpdateAnnotations != nil {
 		return m.Impl.UpdateAnnotations(ctx, planId, annotations)
+	}
+
+	panic(errors.New("should not be called"))
+}
+
+func (m *PlanInterface) SetServiceAccount(ctx context.Context, planId string, serviceAccount string) error {
+	m.Calls.SetServiceAccount = append(m.Calls.SetServiceAccount, SetServiceAccountArgs{
+		PlanId:         planId,
+		ServiceAccount: serviceAccount,
+	})
+	if m.Impl.SetServiceAccount != nil {
+		return m.Impl.SetServiceAccount(ctx, planId, serviceAccount)
+	}
+
+	panic(errors.New("should not be called"))
+}
+
+func (m *PlanInterface) UnsetServiceAccount(ctx context.Context, planId string) error {
+	m.Calls.UnsetServiceAccount = append(m.Calls.UnsetServiceAccount, planId)
+	if m.Impl.UnsetServiceAccount != nil {
+		return m.Impl.UnsetServiceAccount(ctx, planId)
 	}
 
 	panic(errors.New("should not be called"))

--- a/pkg/db/plan.go
+++ b/pkg/db/plan.go
@@ -152,6 +152,34 @@ type PlanInterface interface {
 	//
 	// - error
 	UpdateAnnotations(context.Context, string, AnnotationDelta) error
+
+	// SetServiceAccount sets the service account for a Plan.
+	//
+	// Args
+	//
+	// - context.Context
+	//
+	// - string : Plan ID
+	//
+	// - string : Service Account name
+	//
+	// Returns
+	//
+	// - error
+	SetServiceAccount(ctx context.Context, planId, serviceAccount string) error
+
+	// UnsetServiceAccount unsets the service account for a Plan.
+	//
+	// Args
+	//
+	// - context.Context
+	//
+	// - string : Plan ID
+	//
+	// Returns
+	//
+	// - error
+	UnsetServiceAccount(ctx context.Context, planId string) error
 }
 
 type Annotation struct {


### PR DESCRIPTION
## About This PR

Make ServiceAccount of Plans mutable.

- Add new WebAPIs, `PUT /api/plans/:planId/serviceaccount` and `DELETE /api/plans/:planId/serviceaccount`
- Add new CLI Subcommand `knit plan serviceaccount`

## Related Issues

closes #186 