### PR TITLE
Feature/#24/workflow overview

### DIFF
--- a/cmd/knit/knitgraph/doc.go
+++ b/cmd/knit/knitgraph/doc.go
@@ -1,0 +1,4 @@
+package knitgraph
+
+// knitgraph is a package for representing a graph (directed acyclic graph (DAG))
+// where the nodes are the Run, Data and Plan.

--- a/cmd/knit/knitgraph/edge.go
+++ b/cmd/knit/knitgraph/edge.go
@@ -1,0 +1,27 @@
+package knitgraph
+
+import (
+	"fmt"
+	"io"
+)
+
+type Edge struct {
+	FromId NodeId
+	ToId   NodeId
+	Label  string
+}
+
+func (e Edge) ToDot(w io.Writer) error {
+	label := ""
+	if e.Label != "" {
+		label = fmt.Sprintf(` [label="%s"]`, e.Label)
+	}
+
+	_, err := fmt.Fprintf(
+		w,
+		`	"%s" -> "%s"%s;
+`,
+		e.FromId, e.ToId, label,
+	)
+	return err
+}

--- a/cmd/knit/knitgraph/graph.go
+++ b/cmd/knit/knitgraph/graph.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/opst/knitfab-api-types/data"
+	"github.com/opst/knitfab-api-types/plans"
 	"github.com/opst/knitfab-api-types/runs"
 	"github.com/opst/knitfab-api-types/tags"
 	"github.com/opst/knitfab/pkg/domain"
@@ -13,7 +14,14 @@ import (
 
 type NodeId string
 
+type MountpointAddress struct {
+	PlanId string
+	Path   string
+	Log    bool
+}
+
 type DirectedGraph struct {
+	PlanNodes maps.Map[string, PlanNode]
 	DataNodes maps.Map[string, DataNode]
 	RunNodes  maps.Map[string, RunNode]
 	RootNodes []RootNode
@@ -21,25 +29,45 @@ type DirectedGraph struct {
 	// Edges
 	Edges []Edge
 
+	thunkPlan    map[string][]func(PlanNode) // key:planId
+	thunkInput   map[MountpointAddress][]func(InputNode)
+	thunkOutput  map[MountpointAddress][]func(OutputNode)
+	thunkPlanLog map[string][]func(PlanLogNode) // key:planId
+
 	thunkData map[string][]func(DataNode) // key:knitId
-	thunkRun  map[string][]func(RunNode)  // key:runId
+
+	thunkRun map[string][]func(RunNode) // key:runId
 }
 
 type Option func(*DirectedGraph)
 
-func WithData(d ...data.Detail) Option {
+func WithData(d data.Detail, style ...StyleOption) Option {
 	return func(g *DirectedGraph) {
-		for _, _d := range d {
-			g.AddDataNode(_d)
-		}
+		g.AddDataNode(d, style...)
 	}
 }
 
-func WithRun(r ...runs.Detail) Option {
+func WithRun(r runs.Detail, style ...StyleOption) Option {
 	return func(g *DirectedGraph) {
-		for _, _r := range r {
-			g.AddRunNode(_r)
-		}
+		g.AddRunNode(r, style...)
+	}
+}
+
+func WithPlan(p plans.Detail, style ...StyleOption) Option {
+	return func(g *DirectedGraph) {
+		g.AddPlanNode(p, style...)
+	}
+}
+
+type Style struct {
+	Emphasize bool
+}
+
+type StyleOption func(*Style)
+
+func Emphasize() StyleOption {
+	return func(s *Style) {
+		s.Emphasize = true
 	}
 }
 
@@ -48,10 +76,15 @@ func NewDirectedGraph(opt ...Option) *DirectedGraph {
 		RootNodes: []RootNode{},
 		DataNodes: maps.NewOrderedMap[string, DataNode](),
 		RunNodes:  maps.NewOrderedMap[string, RunNode](),
+		PlanNodes: maps.NewOrderedMap[string, PlanNode](),
 		Edges:     []Edge{},
 
-		thunkData: map[string][]func(DataNode){},
-		thunkRun:  map[string][]func(RunNode){},
+		thunkData:    map[string][]func(DataNode){},
+		thunkRun:     map[string][]func(RunNode){},
+		thunkPlan:    map[string][]func(PlanNode){},
+		thunkInput:   map[MountpointAddress][]func(InputNode){},
+		thunkOutput:  map[MountpointAddress][]func(OutputNode){},
+		thunkPlanLog: map[string][]func(PlanLogNode){},
 	}
 
 	for _, o := range opt {
@@ -61,9 +94,14 @@ func NewDirectedGraph(opt ...Option) *DirectedGraph {
 	return g
 }
 
-func (g *DirectedGraph) AddDataNode(data data.Detail) NodeId {
+func (g *DirectedGraph) AddDataNode(data data.Detail, styles ...StyleOption) NodeId {
+	style := Style{}
+	for _, s := range styles {
+		s(&style)
+	}
+
 	nodeId := NodeId("d" + data.KnitId)
-	newNode := DataNode{NodeId: nodeId, Detail: data}
+	newNode := DataNode{NodeId: nodeId, Detail: data, Emphasize: style.Emphasize}
 	g.DataNodes.Set(data.KnitId, newNode)
 
 	for _, thunk := range g.thunkData[data.KnitId] {
@@ -79,13 +117,17 @@ func (g *DirectedGraph) AddDataNode(data data.Detail) NodeId {
 				thunks = []func(RunNode){}
 				g.thunkRun[upstreamId] = thunks
 			}
-			g.thunkRun[upstreamId] = append(thunks, func(run RunNode) {
-				if log := run.Log; log != nil && log.KnitId == data.KnitId {
+			if log := data.Upstream.Log; log != nil {
+				g.thunkRun[upstreamId] = append(thunks, func(run RunNode) {
 					g.addEdge(run.NodeId, newNode.NodeId, "(log)")
-					return
-				}
-				g.addEdge(run.NodeId, newNode.NodeId, data.Upstream.Path)
-			})
+				})
+			}
+
+			if mp := data.Upstream.Mountpoint; mp != nil {
+				g.thunkRun[upstreamId] = append(thunks, func(run RunNode) {
+					g.addEdge(run.NodeId, newNode.NodeId, mp.Path)
+				})
+			}
 		}
 	}
 
@@ -100,16 +142,173 @@ func (g *DirectedGraph) AddDataNode(data data.Detail) NodeId {
 			g.thunkRun[downstreamId] = thunks
 		}
 		g.thunkRun[downstreamId] = append(thunks, func(run RunNode) {
-			g.addEdge(newNode.NodeId, run.NodeId, ds.Path)
+			g.addEdge(newNode.NodeId, run.NodeId, ds.Mountpoint.Path)
 		})
 	}
 
 	return newNode.NodeId
 }
 
-func (g *DirectedGraph) AddRunNode(run runs.Detail) NodeId {
+func (g *DirectedGraph) AddPlanNode(plan plans.Detail, styles ...StyleOption) NodeId {
+	style := Style{}
+	for _, s := range styles {
+		s(&style)
+	}
+
+	nodeId := NodeId("p" + plan.PlanId)
+	newNode := PlanNode{
+		NodeId:      nodeId,
+		Detail:      plan,
+		InputNodes:  maps.NewOrderedMap[string, InputNode](),
+		OutputNodes: maps.NewOrderedMap[string, OutputNode](),
+		Emphasize:   style.Emphasize,
+	}
+
+	{
+		// build PlanNode
+		for _, in := range plan.Inputs {
+			newNode.InputNodes.Set(in.Path, InputNode{
+				NodeId: NodeId(fmt.Sprintf("p%s@%s", plan.PlanId, in.Path)),
+				Input:  in,
+			})
+		}
+
+		for _, out := range plan.Outputs {
+			newNode.OutputNodes.Set(out.Path, OutputNode{
+				NodeId: NodeId(fmt.Sprintf("p%s@%s", plan.PlanId, out.Path)),
+				Output: out,
+			})
+		}
+
+		if log := plan.Log; log != nil {
+			newNode.LogNode = &PlanLogNode{
+				NodeId: NodeId(fmt.Sprintf("p%s@log", plan.PlanId)),
+				Log:    *log,
+			}
+		}
+	}
+
+	g.PlanNodes.Set(plan.PlanId, newNode)
+	{
+		// invoke thunks for each registered nodes (Plan, Input, Output, Log)
+		for _, thunk := range g.thunkPlan[plan.PlanId] {
+			thunk(newNode)
+		}
+		delete(g.thunkPlan, plan.PlanId)
+
+		for _, in := range newNode.InputNodes.Iter() {
+			mpaddr := MountpointAddress{PlanId: plan.PlanId, Path: in.Input.Path}
+			for _, thunk := range g.thunkInput[mpaddr] {
+				thunk(in)
+			}
+			delete(g.thunkInput, mpaddr)
+		}
+
+		for _, out := range newNode.OutputNodes.Iter() {
+			mpaddr := MountpointAddress{PlanId: plan.PlanId, Path: out.Output.Path}
+			for _, thunk := range g.thunkOutput[mpaddr] {
+				thunk(out)
+			}
+			delete(g.thunkOutput, mpaddr)
+		}
+
+		if log := newNode.LogNode; log != nil {
+			for _, thunk := range g.thunkPlanLog[plan.PlanId] {
+				thunk(*log)
+			}
+			delete(g.thunkPlanLog, plan.PlanId)
+		}
+	}
+
+	{
+		// register thunks for each upstreams and downstreams
+
+		for _, in := range newNode.InputNodes.Iter() {
+			for _, ups := range in.Upstreams {
+				if log := ups.Log; log != nil {
+					if uPlan, ok := g.PlanNodes.Get(ups.Plan.PlanId); ok {
+						if uLog := uPlan.LogNode; uLog != nil {
+							continue
+						}
+					}
+
+					thunks, ok := g.thunkPlanLog[ups.Plan.PlanId]
+					if !ok {
+						thunks = []func(PlanLogNode){}
+					}
+
+					g.thunkPlanLog[ups.Plan.PlanId] = append(thunks, func(log PlanLogNode) {
+						g.addEdge(log.NodeId, in.NodeId, "")
+					})
+				} else if mp := ups.Mountpoint; mp != nil {
+					mpaddr := MountpointAddress{PlanId: ups.Plan.PlanId, Path: mp.Path}
+
+					if uPlan, ok := g.PlanNodes.Get(ups.Plan.PlanId); ok {
+						if _, ok := uPlan.OutputNodes.Get(mpaddr.Path); ok {
+							continue
+						}
+					}
+
+					thunks, ok := g.thunkOutput[mpaddr]
+					if !ok {
+						thunks = []func(OutputNode){}
+					}
+
+					g.thunkOutput[mpaddr] = append(thunks, func(out OutputNode) {
+						g.addEdge(out.NodeId, in.NodeId, "")
+					})
+				}
+			}
+		}
+
+		for _, out := range newNode.OutputNodes.Iter() {
+			for _, ds := range out.Downstreams {
+				mpaddr := MountpointAddress{PlanId: ds.Plan.PlanId, Path: ds.Mountpoint.Path}
+
+				if dPlan, ok := g.PlanNodes.Get(ds.Plan.PlanId); ok {
+					if _, ok := dPlan.InputNodes.Get(mpaddr.Path); ok {
+						continue
+					}
+				}
+
+				thunks, ok := g.thunkInput[mpaddr]
+				if !ok {
+					thunks = []func(InputNode){}
+				}
+				g.thunkInput[mpaddr] = append(thunks, func(in InputNode) {
+					g.addEdge(out.NodeId, in.NodeId, "")
+				})
+			}
+		}
+
+		if logNode := newNode.LogNode; logNode != nil {
+			for _, ds := range logNode.Downstreams {
+				mpaddr := MountpointAddress{PlanId: ds.Plan.PlanId, Path: ds.Mountpoint.Path}
+				if _, ok := g.PlanNodes.Get(ds.Plan.PlanId); ok {
+					continue
+				}
+				thunks, ok := g.thunkInput[mpaddr]
+				if !ok {
+					thunks = []func(InputNode){}
+				}
+				g.thunkInput[mpaddr] = append(thunks, func(in InputNode) {
+					g.addEdge(logNode.NodeId, in.NodeId, "")
+				})
+			}
+		}
+	}
+
+	return newNode.NodeId
+}
+
+func (g *DirectedGraph) AddRunNode(run runs.Detail, styles ...StyleOption) NodeId {
+	style := Style{}
+	for _, s := range styles {
+		s(&style)
+	}
+
 	nodeId := NodeId("r" + run.RunId)
-	newNode := RunNode{NodeId: nodeId, Detail: run}
+	newNode := RunNode{NodeId: nodeId, Detail: run, Emphasize: style.Emphasize}
 	g.RunNodes.Set(run.RunId, newNode)
 
 	for _, thunk := range g.thunkRun[run.RunId] {
@@ -132,16 +331,17 @@ func (g *DirectedGraph) AddRunNode(run runs.Detail) NodeId {
 	}
 
 	for _, out := range run.Outputs {
-		if _, ok := g.DataNodes.Get(out.KnitId); !ok {
-			thunks, ok := g.thunkData[out.KnitId]
-			if !ok {
-				thunks = []func(DataNode){}
-				g.thunkData[out.KnitId] = thunks
-			}
-			g.thunkData[out.KnitId] = append(thunks, func(data DataNode) {
-				g.addEdge(newNode.NodeId, data.NodeId, out.Path)
-			})
+		if _, ok := g.DataNodes.Get(out.KnitId); ok {
+			continue
 		}
+		thunks, ok := g.thunkData[out.KnitId]
+		if !ok {
+			thunks = []func(DataNode){}
+			g.thunkData[out.KnitId] = thunks
+		}
+		g.thunkData[out.KnitId] = append(thunks, func(data DataNode) {
+			g.addEdge(newNode.NodeId, data.NodeId, out.Path)
+		})
 	}
 
 	if log := run.Log; log != nil {
@@ -152,7 +352,7 @@ func (g *DirectedGraph) AddRunNode(run runs.Detail) NodeId {
 				g.thunkData[log.KnitId] = thunks
 			}
 			g.thunkData[log.KnitId] = append(thunks, func(data DataNode) {
-				g.addEdge(data.NodeId, newNode.NodeId, "(log)")
+				g.addEdge(newNode.NodeId, data.NodeId, "(log)")
 			})
 		}
 	}
@@ -176,14 +376,19 @@ func (g *DirectedGraph) addEdge(fromId, toId NodeId, label string) {
 	g.Edges = append(g.Edges, Edge{FromId: fromId, ToId: toId, Label: label})
 }
 
-func (g *DirectedGraph) GenerateDotFromNodes(w io.Writer, argKnitId string) error {
+func (g *DirectedGraph) GenerateDotFromNodes(w io.Writer) error {
 	for _, data := range g.DataNodes.Iter() {
-		if err := data.ToDot(w, argKnitId == data.KnitId); err != nil {
+		if err := data.ToDot(w); err != nil {
 			return err
 		}
 	}
 	for _, run := range g.RunNodes.Iter() {
 		if err := run.ToDot(w); err != nil {
+			return err
+		}
+	}
+	for _, plan := range g.PlanNodes.Iter() {
+		if err := plan.ToDot(w); err != nil {
 			return err
 		}
 	}
@@ -204,7 +409,7 @@ func (g DirectedGraph) GenerateDotFromEdges(w io.Writer) error {
 	return nil
 }
 
-func (g *DirectedGraph) GenerateDot(w io.Writer, argKnitId string) error {
+func (g *DirectedGraph) GenerateDot(w io.Writer) error {
 	_, err := w.Write([]byte(`digraph G {
 	node [shape=record fontsize=10]
 	edge [fontsize=10]
@@ -214,7 +419,7 @@ func (g *DirectedGraph) GenerateDot(w io.Writer, argKnitId string) error {
 		return err
 	}
 
-	err = g.GenerateDotFromNodes(w, argKnitId)
+	err = g.GenerateDotFromNodes(w)
 	if err != nil {
 		return err
 	}

--- a/cmd/knit/knitgraph/graph.go
+++ b/cmd/knit/knitgraph/graph.go
@@ -1,0 +1,339 @@
+package knitgraph
+
+import (
+	"fmt"
+	"html"
+	"io"
+	"strings"
+
+	"github.com/opst/knitfab-api-types/data"
+	"github.com/opst/knitfab-api-types/misc/rfctime"
+	"github.com/opst/knitfab-api-types/runs"
+	"github.com/opst/knitfab-api-types/tags"
+	"github.com/opst/knitfab/pkg/domain"
+	"github.com/opst/knitfab/pkg/utils/cmp"
+)
+
+type DirectedGraph struct {
+	DataNodes     map[string]DataNode
+	RunNodes      map[string]RunNode
+	RootNodes     []string          //to runId
+	EdgesFromRun  map[string][]Edge //key:from runId, value:to knitId
+	EdgesFromData map[string][]Edge //key:from knitId, value:to runId
+	//The order of these array becomes the order of description when outputting to the dot format.
+	KeysDataNode []string
+	KeysRunNode  []string
+}
+
+func NewDirectedGraph() *DirectedGraph {
+	return &DirectedGraph{
+		DataNodes:     map[string]DataNode{},
+		RunNodes:      map[string]RunNode{},
+		RootNodes:     []string{},
+		EdgesFromRun:  map[string][]Edge{},
+		EdgesFromData: map[string][]Edge{},
+		KeysDataNode:  make([]string, 0),
+		KeysRunNode:   make([]string, 0),
+	}
+}
+
+type DataNode struct {
+	KnitId string
+	Tags   []tags.Tag
+	// FromRunId is coreresponding runId in Upstream of apidata.Detail.
+	// ToRunIds is coreresponding runIds in Downstreams of apidata.Detail.
+	// The reason for holding these two types of runIds in this node is related to the data tracking algorithm.
+	// According to the algorithm's specifications, when data is first identified,
+	// there may be runIds contained in that data that are not yet determined to be added to the graph.
+	// The timing for confirming the addition is when the algorithm identifies that data again.
+	FromRunId string
+	ToRunIds  []string
+}
+
+func (d *DataNode) Equal(o *DataNode) bool {
+	return d.KnitId == o.KnitId &&
+		cmp.SliceContentEqWith(d.Tags, o.Tags, tags.Tag.Equal)
+}
+
+func (d *DataNode) ToDot(w io.Writer, isArgKnitId bool) error {
+	knitId := d.KnitId
+
+	systemtag := []string{}
+	userTags := []string{}
+	for _, tag := range d.Tags {
+		switch tag.Key {
+		case domain.KeyKnitTimestamp:
+			tsp, err := rfctime.ParseRFC3339DateTime(tag.Value)
+			if err != nil {
+				return err
+			}
+			systemtag = append(
+				systemtag,
+				html.EscapeString(tsp.Time().Local().Format(rfctime.RFC3339DateTimeFormat)),
+			)
+			continue
+		case domain.KeyKnitTransient:
+			systemtag = append(systemtag, html.EscapeString(tag.String()))
+			continue
+		case tags.KeyKnitId:
+			continue
+		}
+
+		userTags = append(
+			userTags,
+			fmt.Sprintf(`<B>%s</B>:%s`, html.EscapeString(tag.Key), html.EscapeString(tag.Value)),
+		)
+	}
+	subheader := ""
+	if len(systemtag) != 0 {
+		subheader = fmt.Sprintf(
+			`<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">%s</FONT></TD></TR>`,
+			strings.Join(systemtag, " | "),
+		)
+	}
+
+	//The background color of the data node that is the argument gets highlighted from the others.
+	bgColor := map[bool]string{true: "#d4ecc6", false: "#FFFFFF"}[isArgKnitId]
+	_, err := fmt.Fprintf(
+		w,
+		`	"d%s"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="%s">knit#id: %s</TD></TR>
+				%s
+				<TR><TD COLSPAN="2">%s</TD></TR>
+			</TABLE>
+		>
+	];
+`,
+		knitId,
+		bgColor,
+		html.EscapeString(knitId),
+		subheader,
+		strings.Join(userTags, "<BR/>"),
+		// "d" is a prefix used to denote a data node in dot format.
+	)
+	return err
+
+}
+
+type RunNode struct {
+	runs.Summary
+}
+
+func (r *RunNode) ToDot(w io.Writer) error {
+	title := ""
+	if r.Plan.Image != nil {
+		title = "image = " + r.Plan.Image.String()
+	} else if r.Plan.Name != "" {
+		title = r.Plan.Name
+	}
+
+	status := html.EscapeString(r.Status)
+	switch domain.KnitRunStatus(r.Status) {
+	case domain.Deactivated:
+		status = fmt.Sprintf(`<FONT COLOR="gray"><B>%s</B></FONT>`, status)
+	case domain.Completing, domain.Done:
+		status = fmt.Sprintf(`<FONT COLOR="#007700"><B>%s</B></FONT>`, status)
+	case domain.Aborting, domain.Failed:
+		status = fmt.Sprintf(`<FONT COLOR="red"><B>%s</B></FONT>`, status)
+	}
+
+	_, err := fmt.Fprintf(
+		w,
+		`	"r%s"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD>%s</TD><TD>id: %s</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
+				<TR><TD COLSPAN="3">%s</TD></TR>
+			</TABLE>
+		>
+	];
+`,
+		r.RunId,
+		status,
+		html.EscapeString(r.RunId),
+		html.EscapeString(r.UpdatedAt.Time().Local().Format(rfctime.RFC3339DateTimeFormat)),
+		html.EscapeString(title),
+		// "r" is a prefix used to denote a run node in dot format.
+	)
+	return err
+}
+
+type Edge struct {
+	ToId  string
+	Label string //mountpath
+}
+
+func (g *DirectedGraph) AddDataNode(data data.Detail) {
+	g.DataNodes[data.KnitId] = DataNode{
+		KnitId:    data.KnitId,
+		Tags:      data.Tags,
+		FromRunId: data.Upstream.Run.RunId,
+		ToRunIds: func() []string {
+			runIds := []string{}
+			for _, ds := range data.Downstreams {
+				runIds = append(runIds, ds.Run.RunId)
+			}
+			return runIds
+		}(),
+	}
+	g.KeysDataNode = append(g.KeysDataNode, data.KnitId)
+}
+
+func (g *DirectedGraph) AddRunNode(run runs.Detail) {
+	g.RunNodes[run.RunId] = RunNode{
+		Summary: run.Summary,
+	}
+	g.KeysRunNode = append(g.KeysRunNode, run.RunId)
+}
+
+// This method assumes that the run nodes of the edge to be added are included in the graph.
+func (g *DirectedGraph) AddRootNode(runId string) {
+	g.RootNodes = append(g.RootNodes, runId)
+}
+
+// This method assumes that the nodes of the edge to be added are included in the graph.
+func (g *DirectedGraph) AddEdgeFromRun(runId string, knitId string, label string) {
+	g.EdgesFromRun[runId] = append(g.EdgesFromRun[runId], Edge{ToId: knitId, Label: label})
+}
+
+// This method assumes that the nodes of the edge to be added are included in the graph.
+func (g *DirectedGraph) AddEdgeFromData(knitId string, runId string, label string) {
+	g.EdgesFromData[knitId] = append(g.EdgesFromData[knitId], Edge{ToId: runId, Label: label})
+}
+
+func (g *DirectedGraph) GenerateDotFromNodes(w io.Writer, argKnitId string) error {
+	for _, knitId := range g.KeysDataNode {
+		if data, ok := g.DataNodes[knitId]; ok {
+			if err := data.ToDot(w, argKnitId == knitId); err != nil {
+				return err
+			}
+		}
+	}
+	for _, runId := range g.KeysRunNode {
+		if run, ok := g.RunNodes[runId]; ok {
+			if err := run.ToDot(w); err != nil {
+				return err
+			}
+		}
+	}
+	for i := range g.RootNodes {
+		_, err := fmt.Fprintf(
+			w,
+			`	"root#%d"[shape=Mdiamond];
+`,
+			i)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g DirectedGraph) GenerateDotFromEdges(w io.Writer) error {
+	err := writeEdgesToDot(w, g.KeysDataNode, g.EdgesFromData, "d", "r")
+	if err != nil {
+		return err
+	}
+
+	err = writeEdgesToDot(w, g.KeysRunNode, g.EdgesFromRun, "r", "d")
+	if err != nil {
+		return err
+	}
+
+	for i, runId := range g.RootNodes {
+		_, err := fmt.Fprintf(
+			w,
+			`	"root#%d" -> "r%s";
+`,
+			i, runId,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeEdgesToDot(
+	w io.Writer,
+	keys []string,
+	edgesMap map[string][]Edge,
+	fromPrefix, toPrefix string) error {
+	for _, id := range keys {
+		if edges, ok := edgesMap[id]; ok {
+			for _, edge := range edges {
+				toId := edge.ToId
+				_, err := fmt.Fprintf(
+					w,
+					`	"%s%s" -> "%s%s" [label="%s"];
+`,
+					fromPrefix, id,
+					toPrefix, toId,
+					edge.Label,
+				)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *DirectedGraph) GenerateDot(w io.Writer, argKnitId string) error {
+	_, err := w.Write([]byte(`digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
+
+`))
+	if err != nil {
+		return err
+	}
+
+	err = g.GenerateDotFromNodes(w, argKnitId)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte("\n"))
+	if err != nil {
+		return err
+	}
+
+	err = g.GenerateDotFromEdges(w)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte("\n}"))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ErrFindDataWithKnitId(knitId string, err error) error {
+	return fmt.Errorf("%w: during searching data %s", err, knitId)
+}
+
+func ErrGetRunWithRunId(runId string, err error) error {
+	return fmt.Errorf("%w: during searching run %s", err, runId)
+}
+
+var ErrNotFoundData = fmt.Errorf("data not found")
+
+func errNotFoundData(knitId string) error {
+	return fmt.Errorf("%w: %s", ErrNotFoundData, knitId)
+}
+
+func knitIdTag(knitId string) tags.Tag {
+	return tags.Tag{
+		Key:   domain.KeyKnitId,
+		Value: knitId,
+	}
+}

--- a/cmd/knit/knitgraph/graph.go
+++ b/cmd/knit/knitgraph/graph.go
@@ -2,16 +2,12 @@ package knitgraph
 
 import (
 	"fmt"
-	"html"
 	"io"
-	"strings"
 
 	"github.com/opst/knitfab-api-types/data"
-	"github.com/opst/knitfab-api-types/misc/rfctime"
 	"github.com/opst/knitfab-api-types/runs"
 	"github.com/opst/knitfab-api-types/tags"
 	"github.com/opst/knitfab/pkg/domain"
-	"github.com/opst/knitfab/pkg/utils/cmp"
 	"github.com/opst/knitfab/pkg/utils/maps"
 )
 
@@ -63,166 +59,6 @@ func NewDirectedGraph(opt ...Option) *DirectedGraph {
 	}
 
 	return g
-}
-
-type RootNode struct {
-	NodeId NodeId
-}
-
-func (r *RootNode) Equal(o *RootNode) bool {
-	return r.NodeId == o.NodeId
-}
-
-func (r *RootNode) ToDot(w io.Writer) error {
-	_, err := fmt.Fprintf(
-		w,
-		`	"%s"[shape=Mdiamond];
-`,
-		r.NodeId,
-	)
-	return err
-}
-
-type DataNode struct {
-	NodeId NodeId
-	data.Detail
-}
-
-func (d *DataNode) Equal(o *DataNode) bool {
-	return d.KnitId == o.KnitId &&
-		cmp.SliceContentEqWith(d.Tags, o.Tags, tags.Tag.Equal)
-}
-
-func (d *DataNode) ToDot(w io.Writer, isArgKnitId bool) error {
-	knitId := d.KnitId
-
-	systemtag := []string{}
-	userTags := []string{}
-	for _, tag := range d.Tags {
-		switch tag.Key {
-		case domain.KeyKnitTimestamp:
-			tsp, err := rfctime.ParseRFC3339DateTime(tag.Value)
-			if err != nil {
-				return err
-			}
-			systemtag = append(
-				systemtag,
-				html.EscapeString(tsp.Time().Local().Format(rfctime.RFC3339DateTimeFormat)),
-			)
-			continue
-		case domain.KeyKnitTransient:
-			systemtag = append(systemtag, html.EscapeString(tag.String()))
-			continue
-		case tags.KeyKnitId:
-			continue
-		}
-
-		userTags = append(
-			userTags,
-			fmt.Sprintf(`<B>%s</B>:%s`, html.EscapeString(tag.Key), html.EscapeString(tag.Value)),
-		)
-	}
-	subheader := ""
-	if len(systemtag) != 0 {
-		subheader = fmt.Sprintf(
-			`<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">%s</FONT></TD></TR>`,
-			strings.Join(systemtag, " | "),
-		)
-	}
-
-	//The background color of the data node that is the argument gets highlighted from the others.
-	bgColor := map[bool]string{true: "#d4ecc6", false: "#FFFFFF"}[isArgKnitId]
-	_, err := fmt.Fprintf(
-		w,
-		`	"%s"[
-		shape=none
-		color="#1c9930"
-		label=<
-			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="%s">knit#id: %s</TD></TR>
-				%s
-				<TR><TD COLSPAN="2">%s</TD></TR>
-			</TABLE>
-		>
-	];
-`,
-		d.NodeId,
-		bgColor,
-		html.EscapeString(knitId),
-		subheader,
-		strings.Join(userTags, "<BR/>"),
-		// "d" is a prefix used to denote a data node in dot format.
-	)
-	return err
-
-}
-
-type RunNode struct {
-	NodeId NodeId
-	runs.Detail
-}
-
-func (r *RunNode) ToDot(w io.Writer) error {
-	title := ""
-	if r.Plan.Image != nil {
-		title = "image = " + r.Plan.Image.String()
-	} else if r.Plan.Name != "" {
-		title = r.Plan.Name
-	}
-
-	status := html.EscapeString(r.Status)
-	switch domain.KnitRunStatus(r.Status) {
-	case domain.Deactivated:
-		status = fmt.Sprintf(`<FONT COLOR="gray"><B>%s</B></FONT>`, status)
-	case domain.Completing, domain.Done:
-		status = fmt.Sprintf(`<FONT COLOR="#007700"><B>%s</B></FONT>`, status)
-	case domain.Aborting, domain.Failed:
-		status = fmt.Sprintf(`<FONT COLOR="red"><B>%s</B></FONT>`, status)
-	}
-
-	_, err := fmt.Fprintf(
-		w,
-		`	"%s"[
-		shape=none
-		color=orange
-		label=<
-			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD>%s</TD><TD>id: %s</TD></TR>
-				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
-				<TR><TD COLSPAN="3">%s</TD></TR>
-			</TABLE>
-		>
-	];
-`,
-		r.NodeId,
-		status,
-		html.EscapeString(r.RunId),
-		html.EscapeString(r.UpdatedAt.Time().Local().Format(rfctime.RFC3339DateTimeFormat)),
-		html.EscapeString(title),
-		// "r" is a prefix used to denote a run node in dot format.
-	)
-	return err
-}
-
-type Edge struct {
-	FromId NodeId
-	ToId   NodeId
-	Label  string
-}
-
-func (e Edge) ToDot(w io.Writer) error {
-	label := ""
-	if e.Label != "" {
-		label = fmt.Sprintf(` [label="%s"]`, e.Label)
-	}
-
-	_, err := fmt.Fprintf(
-		w,
-		`	"%s" -> "%s"%s;
-`,
-		e.FromId, e.ToId, label,
-	)
-	return err
 }
 
 func (g *DirectedGraph) AddDataNode(data data.Detail) NodeId {

--- a/cmd/knit/knitgraph/graph_test.go
+++ b/cmd/knit/knitgraph/graph_test.go
@@ -2,7 +2,6 @@ package knitgraph_test
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"testing"
 
@@ -18,8 +17,7 @@ import (
 
 func TestGenerateDot(t *testing.T) {
 	type When struct {
-		Graph     *knitgraph.DirectedGraph
-		ArgKnitId string
+		Graph *knitgraph.DirectedGraph
 	}
 	type Then struct {
 		RequiredContent string
@@ -28,7 +26,7 @@ func TestGenerateDot(t *testing.T) {
 		return func(t *testing.T) {
 			w := new(strings.Builder)
 
-			if err := when.Graph.GenerateDot(w, when.ArgKnitId); err != nil {
+			if err := when.Graph.GenerateDot(w); err != nil {
 				t.Fatal(err)
 			}
 
@@ -48,12 +46,12 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data1"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:55+00:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: runs.Summary{
 					RunId: "run0", Status: "done",
 					Plan: plans.Summary{PlanId: "upload", Name: "knit#uploaded"},
 				},
-				Mountpoint: plans.Mountpoint{Path: "/out/1"},
+				Mountpoint: &plans.Mountpoint{Path: "/out/1"},
 			},
 			Downstreams: []data.AssignedTo{
 				{
@@ -79,7 +77,7 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data2"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: runs.Summary{
 					RunId: "run1", Status: "done",
 					Plan: plans.Summary{
@@ -87,7 +85,7 @@ func TestGenerateDot(t *testing.T) {
 						Image:  &plans.Image{Repository: "knit.image.repo.invalid/trainer", Tag: "v1"},
 					},
 				},
-				Mountpoint: plans.Mountpoint{Path: "/out/1"},
+				Mountpoint: &plans.Mountpoint{Path: "/out/1"},
 			},
 		}
 		run1 := runs.Detail{
@@ -117,10 +115,10 @@ func TestGenerateDot(t *testing.T) {
 		t.Run("When graph have nodes and edges, then they should be output as dot format.", theory(
 			When{
 				Graph: knitgraph.NewDirectedGraph(
-					knitgraph.WithData(data1, data2),
+					knitgraph.WithData(data1, knitgraph.Emphasize()),
+					knitgraph.WithData(data2),
 					knitgraph.WithRun(run1),
 				),
-				ArgKnitId: "data1",
 			},
 			Then{
 				RequiredContent: fmt.Sprintf(
@@ -152,10 +150,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun1"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: run1</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
 			</TABLE>
@@ -203,7 +201,7 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data1"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: runs.Summary{
 					RunId: "run1", Status: "done",
 					Plan: plans.Summary{
@@ -211,7 +209,7 @@ func TestGenerateDot(t *testing.T) {
 						Name:   "knit#uploaded",
 					},
 				},
-				Mountpoint: plans.Mountpoint{Path: "/upload"},
+				Mountpoint: &plans.Mountpoint{Path: "/upload"},
 			},
 			Downstreams: []data.AssignedTo{
 				{
@@ -264,7 +262,7 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data2"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: runs.Summary{
 					RunId: "run2", Status: "done",
 					Plan: plans.Summary{
@@ -275,18 +273,17 @@ func TestGenerateDot(t *testing.T) {
 						},
 					},
 				},
-				Mountpoint: plans.Mountpoint{Path: "/out/1"},
+				Mountpoint: &plans.Mountpoint{Path: "/out/1"},
 			},
 		}
 		t.Run("Confirm that when nodes, edges, and roots exist in the graph, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.NewDirectedGraph(
-					knitgraph.WithData(data2),
+					knitgraph.WithData(data2, knitgraph.Emphasize()),
 					knitgraph.WithRun(run2),
 					knitgraph.WithData(data1),
-					knitgraph.WithRun(run1),
+					knitgraph.WithRun(run1, knitgraph.Emphasize()),
 				),
-				ArgKnitId: "data2",
 			},
 			Then{
 				RequiredContent: fmt.Sprintf(`digraph G {
@@ -317,10 +314,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun2"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run2</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: run2</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v2</TD></TR>
 			</TABLE>
@@ -328,10 +325,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun1"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD BGCOLOR="#FFD580">id: run1</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">knit#uploaded</TD></TR>
 			</TABLE>
@@ -385,9 +382,9 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data1"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run:        run1.Summary,
-				Mountpoint: plans.Mountpoint{Path: "/upload"},
+				Mountpoint: &plans.Mountpoint{Path: "/upload"},
 			},
 			Downstreams: []data.AssignedTo{
 				{
@@ -443,9 +440,9 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
 				{Key: domain.KeyKnitTransient, Value: "failed"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run:        run2.Summary,
-				Mountpoint: plans.Mountpoint{Path: "/out/1"},
+				Mountpoint: &plans.Mountpoint{Path: "/out/1"},
 			},
 		}
 		log := data.Detail{
@@ -457,19 +454,21 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
 				{Key: domain.KeyKnitTransient, Value: "failed"},
 			},
-			Upstream: data.AssignedTo{
-				Run:        run2.Summary,
-				Mountpoint: plans.Mountpoint{Path: "/log"},
+			Upstream: data.CreatedFrom{
+				Run: run2.Summary,
+				Log: &plans.LogPoint{},
 			},
 		}
 
 		t.Run("When there are failed run and its output, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.NewDirectedGraph(
-					knitgraph.WithData(data1, data2, log),
-					knitgraph.WithRun(run1, run2),
+					knitgraph.WithData(data1, knitgraph.Emphasize()),
+					knitgraph.WithData(data2),
+					knitgraph.WithData(log),
+					knitgraph.WithRun(run1),
+					knitgraph.WithRun(run2),
 				),
-				ArgKnitId: "data1",
 			},
 			Then{
 				RequiredContent: fmt.Sprintf(
@@ -512,10 +511,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun1"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: run1</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">knit#uploaded</TD></TR>
 			</TABLE>
@@ -523,10 +522,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun2"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="red"><B>failed</B></FONT></TD><TD>id: run2</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="red"><B>failed</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: run2</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
 			</TABLE>
@@ -636,12 +635,12 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data1"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: runs.Summary{
 					RunId: "run0", Status: "done",
 					Plan: plans.Summary{PlanId: "upload", Name: "knit#uploaded"},
 				},
-				Mountpoint: plans.Mountpoint{Path: "/out/1"},
+				Mountpoint: &plans.Mountpoint{Path: "/out/1"},
 			},
 			Downstreams: []data.AssignedTo{
 				{
@@ -660,9 +659,9 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data2"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: run1.Summary,
-				Mountpoint: plans.Mountpoint{
+				Mountpoint: &plans.Mountpoint{
 					Path: "/out/1",
 				},
 			},
@@ -684,9 +683,9 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data3"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: run1.Summary,
-				Mountpoint: plans.Mountpoint{
+				Mountpoint: &plans.Mountpoint{
 					Path: "/out/2",
 				},
 			},
@@ -708,12 +707,12 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data4"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: runs.Summary{
 					RunId: "runxx", Status: "done",
 					Plan: plans.Summary{PlanId: "plan-xx", Name: "knit#xx"},
 				},
-				Mountpoint: plans.Mountpoint{
+				Mountpoint: &plans.Mountpoint{
 					Path: "/out/xx",
 				},
 			},
@@ -734,9 +733,9 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data5"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: run2.Summary,
-				Mountpoint: plans.Mountpoint{
+				Mountpoint: &plans.Mountpoint{
 					Path: "/out/3",
 				},
 			},
@@ -750,9 +749,9 @@ func TestGenerateDot(t *testing.T) {
 				{Key: domain.KeyKnitId, Value: "data6"},
 				{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T21:34:56+09:00"},
 			},
-			Upstream: data.AssignedTo{
+			Upstream: data.CreatedFrom{
 				Run: run3.Summary,
-				Mountpoint: plans.Mountpoint{
+				Mountpoint: &plans.Mountpoint{
 					Path: "/out/4",
 				},
 			},
@@ -761,14 +760,16 @@ func TestGenerateDot(t *testing.T) {
 		t.Run("Confirm that when the graph configuration is complex, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.NewDirectedGraph(
-					knitgraph.WithData(data1),
+					knitgraph.WithData(data1, knitgraph.Emphasize()),
 					knitgraph.WithRun(run1),
-					knitgraph.WithData(data2, data3),
-					knitgraph.WithRun(run2, run3),
+					knitgraph.WithData(data2),
+					knitgraph.WithData(data3),
+					knitgraph.WithRun(run2),
+					knitgraph.WithRun(run3),
 					knitgraph.WithData(data4),
-					knitgraph.WithData(data5, data6),
+					knitgraph.WithData(data5),
+					knitgraph.WithData(data6),
 				),
-				ArgKnitId: "data1",
 			},
 			Then{
 				RequiredContent: fmt.Sprintf(
@@ -844,10 +845,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun1"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: run1</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
 			</TABLE>
@@ -855,10 +856,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun2"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run2</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: run2</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v2</TD></TR>
 			</TABLE>
@@ -866,10 +867,10 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"rrun3"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run3</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: run3</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v3</TD></TR>
 			</TABLE>
@@ -908,175 +909,277 @@ func TestGenerateDot(t *testing.T) {
 			},
 		))
 	}
-}
 
-func dummyAssignedTo(runId string) data.AssignedTo {
-	return data.AssignedTo{
-		Run: runs.Summary{
-			RunId:  runId,
-			Status: "done",
-			Plan: plans.Summary{
-				PlanId: "plan-3",
-				Image:  &plans.Image{Repository: "knit.image.repo.invalid/trainer", Tag: "v1"},
+	{
+		plan0 := plans.Detail{
+			Summary: plans.Summary{
+				PlanId: "plan0",
+				Name:   "knit#uploaded",
 			},
-		},
-		Mountpoint: plans.Mountpoint{Path: "/out"},
-	}
-}
+			Inputs: []plans.Input{},
+			Outputs: []plans.Output{
+				{
+					Mountpoint:  plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{},
+				},
+			},
+		}
 
-func dummySliceAssignedTo(runIds ...string) []data.AssignedTo {
-	slice := []data.AssignedTo{}
-	for _, runId := range runIds {
-		element := dummyAssignedTo(runId)
-		slice = append(slice, element)
-	}
-	return slice
-}
-
-func dummyData(knitId string, fromRunId string, toRunIds ...string) data.Detail {
-	return data.Detail{
-		KnitId: knitId,
-		Tags: []tags.Tag{
-			{Key: "foo", Value: "bar"},
-			{Key: "fizz", Value: "bazz"},
-			{Key: domain.KeyKnitId, Value: knitId},
-			{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
-		},
-		Upstream:    dummyAssignedTo(fromRunId),
-		Downstreams: dummySliceAssignedTo(toRunIds...),
-		Nomination:  []data.NominatedBy{},
-	}
-}
-
-func dummyDataForFailed(knitId string, fromRunId string, toRunIds ...string) data.Detail {
-	return data.Detail{
-		KnitId: knitId,
-		Tags: []tags.Tag{
-			{Key: "foo", Value: "bar"},
-			{Key: "fizz", Value: "bazz"},
-			{Key: domain.KeyKnitId, Value: knitId},
-			{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
-			{Key: domain.KeyKnitTransient, Value: domain.ValueKnitTransientFailed},
-		},
-		Upstream:    dummyAssignedTo(fromRunId),
-		Downstreams: dummySliceAssignedTo(toRunIds...),
-		Nomination:  []data.NominatedBy{},
-	}
-}
-
-func dummyRun(runId string, inputs map[string]string, outputs map[string]string) runs.Detail {
-	return runs.Detail{
-		Summary: runs.Summary{
-			RunId:  runId,
-			Status: "done",
-			Plan: plans.Summary{
-				PlanId: "test-Id",
+		plan1 := plans.Detail{
+			Summary: plans.Summary{
+				PlanId: "plan1",
 				Image: &plans.Image{
-					Repository: "test-image",
-					Tag:        "test-version",
+					Repository: "knit.image.repo.invalid/trainer",
+					Tag:        "v1",
 				},
-				Name: "test-Name",
 			},
-		},
-		Inputs:  dummySliceAssignment(inputs),
-		Outputs: dummySliceAssignment(outputs),
-		Log:     nil,
-	}
-}
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams:  []plans.Upstream{},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "plan2"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		}
 
-func dummyRunWithLog(runId string, knitId string, inputs map[string]string, outputs map[string]string) runs.Detail {
-	return runs.Detail{
-		Summary: runs.Summary{
-			RunId:  runId,
-			Status: "done",
-			Plan: plans.Summary{
-				PlanId: "test-Id",
+		plan2 := plans.Detail{
+			Summary: plans.Summary{
+				PlanId: "plan2",
 				Image: &plans.Image{
-					Repository: "test-image",
-					Tag:        "test-version",
+					Repository: "knit.image.repo.invalid/trainer",
+					Tag:        "v1",
 				},
-				Name: "test-Name",
-			},
-		},
-		Inputs:  dummySliceAssignment(inputs),
-		Outputs: dummySliceAssignment(outputs),
-		Log: &runs.LogSummary{
-			LogPoint: plans.LogPoint{
-				Tags: []tags.Tag{
-					{Key: "type", Value: "log"},
-					{Key: "format", Value: "jsonl"},
+				Annotations: []plans.Annotation{
+					{Key: "foo", Value: "bar"},
 				},
 			},
-			KnitId: knitId,
-		},
-	}
-}
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "plan1"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Log: &plans.Log{
+				LogPoint: plans.LogPoint{},
+				Downstreams: []plans.Downstream{
+					{
+						Plan:       plans.Summary{PlanId: "plan3"},
+						Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					},
+				},
+			},
+		}
 
-func dummyFailedRunWithLog(runId string, knitId string, inputs map[string]string, outputs map[string]string) runs.Detail {
-	return runs.Detail{
-		Summary: runs.Summary{
-			RunId:  runId,
-			Status: "failed",
-			Plan: plans.Summary{
-				PlanId: "test-Id",
+		plan3 := plans.Detail{
+			Summary: plans.Summary{
+				PlanId: "plan3",
 				Image: &plans.Image{
-					Repository: "test-image",
-					Tag:        "test-version",
+					Repository: "knit.image.repo.invalid/trainer",
+					Tag:        "v1",
 				},
-				Name: "test-Name",
-			},
-		},
-		Inputs:  dummySliceAssignment(inputs),
-		Outputs: dummySliceAssignment(outputs),
-		Log: &runs.LogSummary{
-			LogPoint: plans.LogPoint{
-				Tags: []tags.Tag{
-					{Key: "type", Value: "log"},
-					{Key: "format", Value: "jsonl"},
+				Annotations: []plans.Annotation{
+					{Key: "foo", Value: "bar"},
+					{Key: "fizz", Value: "bazz"},
 				},
 			},
-			KnitId: knitId,
-		},
-	}
-}
-
-func dummyLogData(knitId string, fromRunId string, toRunIds ...string) data.Detail {
-	return data.Detail{
-		KnitId: knitId,
-		Tags: []tags.Tag{
-			{Key: "type", Value: "log"},
-			{Key: "format", Value: "jsonl"},
-		},
-		Upstream:    dummyAssignedTo(fromRunId),
-		Downstreams: dummySliceAssignedTo(toRunIds...),
-		Nomination:  []data.NominatedBy{},
-	}
-}
-
-func dummyAssignment(knitId string, mountPath string) runs.Assignment {
-	return runs.Assignment{
-		Mountpoint: plans.Mountpoint{
-			Path: mountPath,
-			Tags: []tags.Tag{
-				{Key: "type", Value: "training data"},
-				{Key: "format", Value: "mask"},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan: plans.Summary{PlanId: "plan2"},
+							Log:  &plans.LogPoint{},
+						},
+					},
+				},
 			},
-		},
-		KnitId: knitId,
-	}
-}
+		}
 
-func dummySliceAssignment(knitIdToMoutPath map[string]string) []runs.Assignment {
-	slice := []runs.Assignment{}
-	keys := make([]string, 0, len(knitIdToMoutPath))
-	for k := range knitIdToMoutPath {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		element := dummyAssignment(k, knitIdToMoutPath[k])
-		slice = append(slice, element)
+		t.Run("When add PlanNodes from upstream to downstream, Graph should be made", theory(
+			When{
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithPlan(plan0),
+					knitgraph.WithPlan(plan1, knitgraph.Emphasize()),
+					knitgraph.WithPlan(plan2),
+					knitgraph.WithPlan(plan3),
+				),
+			},
+			Then{
+				RequiredContent: `digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
 
+	subgraph {
+		"pplan0"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan0</TD></TR>
+					<TR><TD COLSPAN="2">knit#uploaded</TD></TR>
+					<TR><TD COLSPAN="2"></TD></TR>
+				</TABLE>
+			>
+		];
+		"pplan0@/out/1"[shape=point, color="#1c9930"];
+		"pplan0" -> "pplan0@/out/1" [label="/out/1"];
 	}
-	return slice
+	subgraph {
+		"pplan1@/in/1"[shape=point, color="#1c9930"];
+		"pplan1@/in/1" -> "pplan1" [label="/in/1"];
+		"pplan1"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#EDD9B4">id: plan1</TD></TR>
+					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="2"></TD></TR>
+				</TABLE>
+			>
+		];
+		"pplan1@/out/1"[shape=point, color="#1c9930"];
+		"pplan1" -> "pplan1@/out/1" [label="/out/1"];
+	}
+	subgraph {
+		"pplan2@/in/1"[shape=point, color="#1c9930"];
+		"pplan2@/in/1" -> "pplan2" [label="/in/1"];
+		"pplan2"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan2</TD></TR>
+					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="2"><B>foo</B>=bar</TD></TR>
+				</TABLE>
+			>
+		];
+		"pplan2@log"[shape=point, color="#1c9930"];
+		"pplan2" -> "pplan2@log" [label="(log)"];
+	}
+	subgraph {
+		"pplan3@/in/1"[shape=point, color="#1c9930"];
+		"pplan3@/in/1" -> "pplan3" [label="/in/1"];
+		"pplan3"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan3</TD></TR>
+					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="2"><B>foo</B>=bar<BR/><B>fizz</B>=bazz</TD></TR>
+				</TABLE>
+			>
+		];
+	}
+
+	"pplan1@/out/1" -> "pplan2@/in/1";
+	"pplan2@log" -> "pplan3@/in/1";
+
+}`,
+			},
+		))
+
+		t.Run("When add PlanNodes from downstream to upstream, Graph should be made", theory(
+			When{
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithPlan(plan3, knitgraph.Emphasize()),
+					knitgraph.WithPlan(plan2),
+					knitgraph.WithPlan(plan1),
+					knitgraph.WithPlan(plan0),
+				),
+			},
+			Then{
+				RequiredContent: `digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
+
+	subgraph {
+		"pplan3@/in/1"[shape=point, color="#1c9930"];
+		"pplan3@/in/1" -> "pplan3" [label="/in/1"];
+		"pplan3"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#EDD9B4">id: plan3</TD></TR>
+					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="2"><B>foo</B>=bar<BR/><B>fizz</B>=bazz</TD></TR>
+				</TABLE>
+			>
+		];
+	}
+	subgraph {
+		"pplan2@/in/1"[shape=point, color="#1c9930"];
+		"pplan2@/in/1" -> "pplan2" [label="/in/1"];
+		"pplan2"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan2</TD></TR>
+					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="2"><B>foo</B>=bar</TD></TR>
+				</TABLE>
+			>
+		];
+		"pplan2@log"[shape=point, color="#1c9930"];
+		"pplan2" -> "pplan2@log" [label="(log)"];
+	}
+	subgraph {
+		"pplan1@/in/1"[shape=point, color="#1c9930"];
+		"pplan1@/in/1" -> "pplan1" [label="/in/1"];
+		"pplan1"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan1</TD></TR>
+					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="2"></TD></TR>
+				</TABLE>
+			>
+		];
+		"pplan1@/out/1"[shape=point, color="#1c9930"];
+		"pplan1" -> "pplan1@/out/1" [label="/out/1"];
+	}
+	subgraph {
+		"pplan0"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan0</TD></TR>
+					<TR><TD COLSPAN="2">knit#uploaded</TD></TR>
+					<TR><TD COLSPAN="2"></TD></TR>
+				</TABLE>
+			>
+		];
+		"pplan0@/out/1"[shape=point, color="#1c9930"];
+		"pplan0" -> "pplan0@/out/1" [label="/out/1"];
+	}
+
+	"pplan2@log" -> "pplan3@/in/1";
+	"pplan1@/out/1" -> "pplan2@/in/1";
+
+}`,
+			},
+		))
+	}
 }

--- a/cmd/knit/knitgraph/graph_test.go
+++ b/cmd/knit/knitgraph/graph_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/opst/knitfab-api-types/tags"
 	"github.com/opst/knitfab/cmd/knit/knitgraph"
 	"github.com/opst/knitfab/pkg/domain"
+	"github.com/opst/knitfab/pkg/utils/maps"
+	"github.com/opst/knitfab/pkg/utils/tuple"
 )
 
 func TestGenerateDot(t *testing.T) {
@@ -41,13 +43,13 @@ func TestGenerateDot(t *testing.T) {
 		t.Run(" Confirm that when only nodes exist in the graph, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1)},
-					RunNodes:      map[string]knitgraph.RunNode{},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+					),
+					RunNodes:      maps.NewOrderedMap[string, knitgraph.RunNode](),
 					EdgesFromData: map[string][]knitgraph.Edge{},
 					EdgesFromRun:  map[string][]knitgraph.Edge{},
 					RootNodes:     []string{},
-					KeysDataNode:  []string{"data1"},
-					KeysRunNode:   []string{},
 				},
 				ArgKnitId: "data1",
 			},
@@ -84,13 +86,16 @@ func TestGenerateDot(t *testing.T) {
 		t.Run(" Confirm that when only nodes, edges, exist in the graph, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run1", Label: "out/1"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "in/1"}, {ToId: "data2", Label: "out/1"}}},
 					RootNodes:     []string{},
-					KeysDataNode:  []string{"data1", "data2"},
-					KeysRunNode:   []string{"run1"},
 				},
 				ArgKnitId: "data1",
 			},
@@ -152,14 +157,18 @@ func TestGenerateDot(t *testing.T) {
 		t.Run("Confirm that when nodes, edges, and roots exist in the graph, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}, "data2": {}},
 					EdgesFromRun: map[string][]knitgraph.Edge{
 						"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}}},
-					KeysDataNode: []string{"data1", "data2"},
-					KeysRunNode:  []string{"run1", "run2"},
-					RootNodes:    []string{"run1"},
+					RootNodes: []string{"run1"},
 				},
 				ArgKnitId: "data2",
 			},
@@ -235,14 +244,19 @@ func TestGenerateDot(t *testing.T) {
 		t.Run("When there are failed run and its output, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2), "log": toDataNode(log)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("log", toDataNode(log)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}, "data2": {}, "log": {}},
 					EdgesFromRun: map[string][]knitgraph.Edge{
 						"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}, {ToId: "log", Label: "(log)"}}},
-					KeysDataNode: []string{"data1", "data2", "log"},
-					KeysRunNode:  []string{"run1", "run2"},
-					RootNodes:    []string{"run1"},
+					RootNodes: []string{"run1"},
 				},
 				ArgKnitId: "data1",
 			},
@@ -336,13 +350,19 @@ func TestGenerateDot(t *testing.T) {
 		t.Run("Confirm that when the graph configuration is complex, they can be output as dot format.", theory(
 			When{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3),
-						"data4": toDataNode(data4), "data5": toDataNode(data5), "data6": toDataNode(data6),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}, "run3": {Summary: run3.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+						tuple.PairOf("data5", toDataNode(data5)),
+						tuple.PairOf("data6", toDataNode(data6)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run2", Label: "in/2"}}, "data3": {{ToId: "run3", Label: "in/4"}},
 						"data4": {{ToId: "run2", Label: "in/3"}}, "data5": {}, "data6": {},
@@ -351,9 +371,7 @@ func TestGenerateDot(t *testing.T) {
 						"run1": {{ToId: "data2", Label: "out/1"}, {ToId: "data3", Label: "out/2"}},
 						"run2": {{ToId: "data5", Label: "out/3"}}, "run3": {{ToId: "data6", Label: "out/4"}},
 					},
-					KeysDataNode: []string{"data1", "data2", "data3", "data4", "data5", "data6"},
-					KeysRunNode:  []string{"run1", "run2", "run3"},
-					RootNodes:    []string{},
+					RootNodes: []string{},
 				},
 				ArgKnitId: "data1",
 			},

--- a/cmd/knit/knitgraph/graph_test.go
+++ b/cmd/knit/knitgraph/graph_test.go
@@ -916,6 +916,7 @@ func TestGenerateDot(t *testing.T) {
 				PlanId: "plan0",
 				Name:   "knit#uploaded",
 			},
+			Active: true,
 			Inputs: []plans.Input{},
 			Outputs: []plans.Output{
 				{
@@ -933,6 +934,7 @@ func TestGenerateDot(t *testing.T) {
 					Tag:        "v1",
 				},
 			},
+			Active: true,
 			Inputs: []plans.Input{
 				{
 					Mountpoint: plans.Mountpoint{Path: "/in/1"},
@@ -963,6 +965,7 @@ func TestGenerateDot(t *testing.T) {
 					{Key: "foo", Value: "bar"},
 				},
 			},
+			Active: true,
 			Inputs: []plans.Input{
 				{
 					Mountpoint: plans.Mountpoint{Path: "/in/1"},
@@ -997,6 +1000,7 @@ func TestGenerateDot(t *testing.T) {
 					{Key: "fizz", Value: "bazz"},
 				},
 			},
+			Active: false,
 			Inputs: []plans.Input{
 				{
 					Mountpoint: plans.Mountpoint{Path: "/in/1"},
@@ -1024,66 +1028,66 @@ func TestGenerateDot(t *testing.T) {
 	node [shape=record fontsize=10]
 	edge [fontsize=10]
 
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan0"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan0</TD></TR>
-					<TR><TD COLSPAN="2">knit#uploaded</TD></TR>
-					<TR><TD COLSPAN="2"></TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#007700"><FONT COLOR="#FFFFFF">active</FONT></TD><TD BGCOLOR="#FFFFFF">id: plan0</TD></TR>
+					<TR><TD COLSPAN="3">knit#uploaded</TD></TR>
+					<TR><TD COLSPAN="3"></TD></TR>
 				</TABLE>
 			>
 		];
-		"pplan0@/out/1"[shape=point, color="#1c9930"];
-		"pplan0" -> "pplan0@/out/1" [label="/out/1"];
+		"pplan0@/out/1"[shape=point, color="#1c9930", margin="0,0"];
+		"pplan0" -> "pplan0@/out/1" [label="/out/1", weight=10, penwidth=0.3];
 	}
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan1@/in/1"[shape=point, color="#1c9930"];
-		"pplan1@/in/1" -> "pplan1" [label="/in/1"];
+		"pplan1@/in/1" -> "pplan1" [label="/in/1", weight=10, penwidth=0.3];
 		"pplan1"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#EDD9B4">id: plan1</TD></TR>
-					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
-					<TR><TD COLSPAN="2"></TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#007700"><FONT COLOR="#FFFFFF">active</FONT></TD><TD BGCOLOR="#EDD9B4">id: plan1</TD></TR>
+					<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="3"></TD></TR>
 				</TABLE>
 			>
 		];
-		"pplan1@/out/1"[shape=point, color="#1c9930"];
-		"pplan1" -> "pplan1@/out/1" [label="/out/1"];
+		"pplan1@/out/1"[shape=point, color="#1c9930", margin="0,0"];
+		"pplan1" -> "pplan1@/out/1" [label="/out/1", weight=10, penwidth=0.3];
 	}
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan2@/in/1"[shape=point, color="#1c9930"];
-		"pplan2@/in/1" -> "pplan2" [label="/in/1"];
+		"pplan2@/in/1" -> "pplan2" [label="/in/1", weight=10, penwidth=0.3];
 		"pplan2"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan2</TD></TR>
-					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
-					<TR><TD COLSPAN="2"><B>foo</B>=bar</TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#007700"><FONT COLOR="#FFFFFF">active</FONT></TD><TD BGCOLOR="#FFFFFF">id: plan2</TD></TR>
+					<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="3"><B>foo</B>=bar</TD></TR>
 				</TABLE>
 			>
 		];
-		"pplan2@log"[shape=point, color="#1c9930"];
-		"pplan2" -> "pplan2@log" [label="(log)"];
+		"pplan2@log"[shape=point, color="#1c9930", margin="0,0"];
+		"pplan2" -> "pplan2@log" [label="(log)", weight=10, penwidth=0.3];
 	}
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan3@/in/1"[shape=point, color="#1c9930"];
-		"pplan3@/in/1" -> "pplan3" [label="/in/1"];
+		"pplan3@/in/1" -> "pplan3" [label="/in/1", weight=10, penwidth=0.3];
 		"pplan3"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan3</TD></TR>
-					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
-					<TR><TD COLSPAN="2"><B>foo</B>=bar<BR/><B>fizz</B>=bazz</TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="gray"><FONT COLOR="#FFFFFF">inactive</FONT></TD><TD BGCOLOR="#FFFFFF">id: plan3</TD></TR>
+					<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="3"><B>foo</B>=bar<BR/><B>fizz</B>=bazz</TD></TR>
 				</TABLE>
 			>
 		];
@@ -1110,69 +1114,69 @@ func TestGenerateDot(t *testing.T) {
 	node [shape=record fontsize=10]
 	edge [fontsize=10]
 
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan3@/in/1"[shape=point, color="#1c9930"];
-		"pplan3@/in/1" -> "pplan3" [label="/in/1"];
+		"pplan3@/in/1" -> "pplan3" [label="/in/1", weight=10, penwidth=0.3];
 		"pplan3"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#EDD9B4">id: plan3</TD></TR>
-					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
-					<TR><TD COLSPAN="2"><B>foo</B>=bar<BR/><B>fizz</B>=bazz</TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="gray"><FONT COLOR="#FFFFFF">inactive</FONT></TD><TD BGCOLOR="#EDD9B4">id: plan3</TD></TR>
+					<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="3"><B>foo</B>=bar<BR/><B>fizz</B>=bazz</TD></TR>
 				</TABLE>
 			>
 		];
 	}
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan2@/in/1"[shape=point, color="#1c9930"];
-		"pplan2@/in/1" -> "pplan2" [label="/in/1"];
+		"pplan2@/in/1" -> "pplan2" [label="/in/1", weight=10, penwidth=0.3];
 		"pplan2"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan2</TD></TR>
-					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
-					<TR><TD COLSPAN="2"><B>foo</B>=bar</TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#007700"><FONT COLOR="#FFFFFF">active</FONT></TD><TD BGCOLOR="#FFFFFF">id: plan2</TD></TR>
+					<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="3"><B>foo</B>=bar</TD></TR>
 				</TABLE>
 			>
 		];
-		"pplan2@log"[shape=point, color="#1c9930"];
-		"pplan2" -> "pplan2@log" [label="(log)"];
+		"pplan2@log"[shape=point, color="#1c9930", margin="0,0"];
+		"pplan2" -> "pplan2@log" [label="(log)", weight=10, penwidth=0.3];
 	}
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan1@/in/1"[shape=point, color="#1c9930"];
-		"pplan1@/in/1" -> "pplan1" [label="/in/1"];
+		"pplan1@/in/1" -> "pplan1" [label="/in/1", weight=10, penwidth=0.3];
 		"pplan1"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan1</TD></TR>
-					<TR><TD COLSPAN="2">image = knit.image.repo.invalid/trainer:v1</TD></TR>
-					<TR><TD COLSPAN="2"></TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#007700"><FONT COLOR="#FFFFFF">active</FONT></TD><TD BGCOLOR="#FFFFFF">id: plan1</TD></TR>
+					<TR><TD COLSPAN="3">image = knit.image.repo.invalid/trainer:v1</TD></TR>
+					<TR><TD COLSPAN="3"></TD></TR>
 				</TABLE>
 			>
 		];
-		"pplan1@/out/1"[shape=point, color="#1c9930"];
-		"pplan1" -> "pplan1@/out/1" [label="/out/1"];
+		"pplan1@/out/1"[shape=point, color="#1c9930", margin="0,0"];
+		"pplan1" -> "pplan1@/out/1" [label="/out/1", weight=10, penwidth=0.3];
 	}
-	subgraph {
+	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 		"pplan0"[
 			shape=none
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#FFFFFF">id: plan0</TD></TR>
-					<TR><TD COLSPAN="2">knit#uploaded</TD></TR>
-					<TR><TD COLSPAN="2"></TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="#007700"><FONT COLOR="#FFFFFF">active</FONT></TD><TD BGCOLOR="#FFFFFF">id: plan0</TD></TR>
+					<TR><TD COLSPAN="3">knit#uploaded</TD></TR>
+					<TR><TD COLSPAN="3"></TD></TR>
 				</TABLE>
 			>
 		];
-		"pplan0@/out/1"[shape=point, color="#1c9930"];
-		"pplan0" -> "pplan0@/out/1" [label="/out/1"];
+		"pplan0@/out/1"[shape=point, color="#1c9930", margin="0,0"];
+		"pplan0" -> "pplan0@/out/1" [label="/out/1", weight=10, penwidth=0.3];
 	}
 
 	"pplan2@log" -> "pplan3@/in/1";

--- a/cmd/knit/knitgraph/graph_test.go
+++ b/cmd/knit/knitgraph/graph_test.go
@@ -1,0 +1,664 @@
+package knitgraph_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/opst/knitfab-api-types/data"
+	"github.com/opst/knitfab-api-types/plans"
+	"github.com/opst/knitfab-api-types/runs"
+	"github.com/opst/knitfab-api-types/tags"
+	"github.com/opst/knitfab/cmd/knit/knitgraph"
+	"github.com/opst/knitfab/pkg/domain"
+)
+
+func TestGenerateDot(t *testing.T) {
+	type When struct {
+		Graph     knitgraph.DirectedGraph
+		ArgKnitId string
+	}
+	type Then struct {
+		RequiredContent string
+	}
+	theory := func(when When, then Then) func(*testing.T) {
+		return func(t *testing.T) {
+			w := new(strings.Builder)
+
+			if err := when.Graph.GenerateDot(w, when.ArgKnitId); err != nil {
+				t.Fatal(err)
+			}
+
+			if w.String() != then.RequiredContent {
+				t.Errorf("fail \nactual:\n%s \n=========\nexpect:\n%s", w.String(), then.RequiredContent)
+			}
+		}
+	}
+	{
+		// [test case of data lineage]
+		// data1 (When there is no downstream for data to be tracked)
+		data1 := dummyData("data1", "run0")
+		t.Run(" Confirm that when only nodes exist in the graph, they can be output as dot format.", theory(
+			When{
+				Graph: knitgraph.DirectedGraph{
+					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1)},
+					RunNodes:      map[string]knitgraph.RunNode{},
+					EdgesFromData: map[string][]knitgraph.Edge{},
+					EdgesFromRun:  map[string][]knitgraph.Edge{},
+					RootNodes:     []string{},
+					KeysDataNode:  []string{"data1"},
+					KeysRunNode:   []string{},
+				},
+				ArgKnitId: "data1",
+			},
+			Then{
+				// The specification is to represent the node name as "r" + runId for run,
+				// and "d" + knitId for data.
+				RequiredContent: `digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
+
+	"ddata1"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#d4ecc6">knit#id: data1</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+
+
+}`,
+			},
+		))
+	}
+	{
+		// [test case of data lineage]
+		// data1 --> [in/1] -->  run1 --> [out/1] --> data2
+		data1 := dummyData("data1", "run0", "run1")
+		data2 := dummyData("data2", "run1")
+		run1 := dummyRun("run1", map[string]string{"data1": "in/1"}, map[string]string{"data2": "out/1"})
+		t.Run(" Confirm that when only nodes, edges, exist in the graph, they can be output as dot format.", theory(
+			When{
+				Graph: knitgraph.DirectedGraph{
+					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
+					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run1", Label: "out/1"}}},
+					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "in/1"}, {ToId: "data2", Label: "out/1"}}},
+					RootNodes:     []string{},
+					KeysDataNode:  []string{"data1", "data2"},
+					KeysRunNode:   []string{"run1"},
+				},
+				ArgKnitId: "data1",
+			},
+			Then{
+				RequiredContent: `digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
+
+	"ddata1"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#d4ecc6">knit#id: data1</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata2"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data2</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun1"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+
+	"ddata1" -> "rrun1" [label="in/1"];
+	"ddata2" -> "rrun1" [label="out/1"];
+	"rrun1" -> "ddata1" [label="in/1"];
+	"rrun1" -> "ddata2" [label="out/1"];
+
+}`,
+			},
+		))
+	}
+	{
+		// [test case of data lineage]
+		// root -->  run1 --> [upload] --> data1 --> [in/1] --> run2 --> [out/1] --> data2
+		run1 := dummyRun("run1", map[string]string{}, map[string]string{"data1": "upload"})
+		data1 := dummyData("data1", "run1")
+		run2 := dummyRun("run2", map[string]string{"data1": "in/1"}, map[string]string{"data2": "out/1"})
+		data2 := dummyData("data2", "run2")
+		t.Run("Confirm that when nodes, edges, and roots exist in the graph, they can be output as dot format.", theory(
+			When{
+				Graph: knitgraph.DirectedGraph{
+					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
+					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}, "data2": {}},
+					EdgesFromRun: map[string][]knitgraph.Edge{
+						"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}}},
+					KeysDataNode: []string{"data1", "data2"},
+					KeysRunNode:  []string{"run1", "run2"},
+					RootNodes:    []string{"run1"},
+				},
+				ArgKnitId: "data2",
+			},
+			Then{
+				RequiredContent: `digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
+
+	"ddata1"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data1</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata2"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#d4ecc6">knit#id: data2</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun1"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun2"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run2</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+	"root#0"[shape=Mdiamond];
+
+	"ddata1" -> "rrun2" [label="in/1"];
+	"rrun1" -> "ddata1" [label="upload"];
+	"rrun2" -> "ddata2" [label="out/1"];
+	"root#0" -> "rrun1";
+
+}`,
+			},
+		))
+	}
+	{
+		// [test case of data lineage]
+		// root -->  run1 --> [upload] --> data1 --> [in/1] --> run2 (failed) --> [out/1] --> data2
+		//                                                                                |-> log
+		run1 := dummyRun("run1", map[string]string{}, map[string]string{"data1": "upload"})
+		data1 := dummyData("data1", "run1")
+		log := dummyDataForFailed("log", "run2")
+		run2 := dummyFailedRunWithLog("run2", "log", map[string]string{"data1": "in/1"}, map[string]string{"data2": "out/1"})
+		data2 := dummyDataForFailed("data2", "run2")
+		t.Run("When there are failed run and its output, they can be output as dot format.", theory(
+			When{
+				Graph: knitgraph.DirectedGraph{
+					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2), "log": toDataNode(log)},
+					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}, "data2": {}, "log": {}},
+					EdgesFromRun: map[string][]knitgraph.Edge{
+						"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}, {ToId: "log", Label: "(log)"}}},
+					KeysDataNode: []string{"data1", "data2", "log"},
+					KeysRunNode:  []string{"run1", "run2"},
+					RootNodes:    []string{"run1"},
+				},
+				ArgKnitId: "data1",
+			},
+			Then{
+				RequiredContent: `digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
+
+	"ddata1"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#d4ecc6">knit#id: data1</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata2"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data2</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00 | knit#transient:failed</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"dlog"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: log</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00 | knit#transient:failed</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun1"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun2"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="red"><B>failed</B></FONT></TD><TD>id: run2</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+	"root#0"[shape=Mdiamond];
+
+	"ddata1" -> "rrun2" [label="in/1"];
+	"rrun1" -> "ddata1" [label="upload"];
+	"rrun2" -> "ddata2" [label="out/1"];
+	"rrun2" -> "dlog" [label="(log)"];
+	"root#0" -> "rrun1";
+
+}`,
+			},
+		))
+	}
+	{
+		// [test case of data lineage]
+		//         	                                  data4 --> [in/3] -|
+		// data1 --> [in/1] -->  run1 --> [out/1] --> data2 --> [in/2] --> run2 --> [out/3] --> data5
+		//					          |-> [out/2] --> data3 --> [in/4] --> run3 --> [out/4] --> data6
+		data1 := dummyData("data1", "run0", "run1")
+		run1 := dummyRun("run1", map[string]string{"data1": "in/1"}, map[string]string{"data2": "out/1", "data3": "out/2"})
+		data2 := dummyData("data2", "run1", "run2")
+		data3 := dummyData("data3", "run1", "run3")
+		run2 := dummyRun("run2", map[string]string{"data2": "in/2", "data4": "in/3"}, map[string]string{"data5": "out/3"})
+		data4 := dummyData("data4", "runxx", "run2")
+		data5 := dummyData("data5", "run2")
+		run3 := dummyRun("run3", map[string]string{"data3": "in/4"}, map[string]string{"data6": "out/4"})
+		data6 := dummyData("data6", "run3")
+
+		t.Run("Confirm that when the graph configuration is complex, they can be output as dot format.", theory(
+			When{
+				Graph: knitgraph.DirectedGraph{
+					DataNodes: map[string]knitgraph.DataNode{
+						"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3),
+						"data4": toDataNode(data4), "data5": toDataNode(data5), "data6": toDataNode(data6),
+					},
+					RunNodes: map[string]knitgraph.RunNode{
+						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}, "run3": {Summary: run3.Summary},
+					},
+					EdgesFromData: map[string][]knitgraph.Edge{
+						"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run2", Label: "in/2"}}, "data3": {{ToId: "run3", Label: "in/4"}},
+						"data4": {{ToId: "run2", Label: "in/3"}}, "data5": {}, "data6": {},
+					},
+					EdgesFromRun: map[string][]knitgraph.Edge{
+						"run1": {{ToId: "data2", Label: "out/1"}, {ToId: "data3", Label: "out/2"}},
+						"run2": {{ToId: "data5", Label: "out/3"}}, "run3": {{ToId: "data6", Label: "out/4"}},
+					},
+					KeysDataNode: []string{"data1", "data2", "data3", "data4", "data5", "data6"},
+					KeysRunNode:  []string{"run1", "run2", "run3"},
+					RootNodes:    []string{},
+				},
+				ArgKnitId: "data1",
+			},
+			Then{
+				RequiredContent: `digraph G {
+	node [shape=record fontsize=10]
+	edge [fontsize=10]
+
+	"ddata1"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#d4ecc6">knit#id: data1</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata2"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data2</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata3"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data3</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata4"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data4</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata5"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data5</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"ddata6"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="#FFFFFF">knit#id: data6</TD></TR>
+				<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">2024-04-01T21:34:56+09:00</FONT></TD></TR>
+				<TR><TD COLSPAN="2"><B>foo</B>:bar<BR/><B>fizz</B>:bazz</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun1"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run1</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun2"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run2</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+	"rrun3"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD><FONT COLOR="#007700"><B>done</B></FONT></TD><TD>id: run3</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: 0001-01-01T09:18:59+09:18</FONT></TD></TR>
+				<TR><TD COLSPAN="3">image = test-image:test-version</TD></TR>
+			</TABLE>
+		>
+	];
+
+	"ddata1" -> "rrun1" [label="in/1"];
+	"ddata2" -> "rrun2" [label="in/2"];
+	"ddata3" -> "rrun3" [label="in/4"];
+	"ddata4" -> "rrun2" [label="in/3"];
+	"rrun1" -> "ddata2" [label="out/1"];
+	"rrun1" -> "ddata3" [label="out/2"];
+	"rrun2" -> "ddata5" [label="out/3"];
+	"rrun3" -> "ddata6" [label="out/4"];
+
+}`,
+			},
+		))
+	}
+}
+
+func toDataNode(data data.Detail) knitgraph.DataNode {
+	return knitgraph.DataNode{
+		KnitId:    data.KnitId,
+		Tags:      data.Tags,
+		FromRunId: data.Upstream.Run.RunId,
+		ToRunIds: func() []string {
+			ids := []string{}
+			for _, downstream := range data.Downstreams {
+				ids = append(ids, downstream.Run.RunId)
+			}
+			return ids
+		}(),
+	}
+}
+
+func dummyAssignedTo(runId string) data.AssignedTo {
+	return data.AssignedTo{
+		Run: runs.Summary{
+			RunId:  runId,
+			Status: "done",
+			Plan: plans.Summary{
+				PlanId: "plan-3",
+				Image:  &plans.Image{Repository: "knit.image.repo.invalid/trainer", Tag: "v1"},
+			},
+		},
+		Mountpoint: plans.Mountpoint{Path: "/out"},
+	}
+}
+
+func dummySliceAssignedTo(runIds ...string) []data.AssignedTo {
+	slice := []data.AssignedTo{}
+	for _, runId := range runIds {
+		element := dummyAssignedTo(runId)
+		slice = append(slice, element)
+	}
+	return slice
+}
+
+func dummyData(knitId string, fromRunId string, toRunIds ...string) data.Detail {
+	return data.Detail{
+		KnitId: knitId,
+		Tags: []tags.Tag{
+			{Key: "foo", Value: "bar"},
+			{Key: "fizz", Value: "bazz"},
+			{Key: domain.KeyKnitId, Value: knitId},
+			{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
+		},
+		Upstream:    dummyAssignedTo(fromRunId),
+		Downstreams: dummySliceAssignedTo(toRunIds...),
+		Nomination:  []data.NominatedBy{},
+	}
+}
+
+func dummyDataForFailed(knitId string, fromRunId string, toRunIds ...string) data.Detail {
+	return data.Detail{
+		KnitId: knitId,
+		Tags: []tags.Tag{
+			{Key: "foo", Value: "bar"},
+			{Key: "fizz", Value: "bazz"},
+			{Key: domain.KeyKnitId, Value: knitId},
+			{Key: domain.KeyKnitTimestamp, Value: "2024-04-01T12:34:56+00:00"},
+			{Key: domain.KeyKnitTransient, Value: domain.ValueKnitTransientFailed},
+		},
+		Upstream:    dummyAssignedTo(fromRunId),
+		Downstreams: dummySliceAssignedTo(toRunIds...),
+		Nomination:  []data.NominatedBy{},
+	}
+}
+
+func dummyRun(runId string, inputs map[string]string, outputs map[string]string) runs.Detail {
+	return runs.Detail{
+		Summary: runs.Summary{
+			RunId:  runId,
+			Status: "done",
+			Plan: plans.Summary{
+				PlanId: "test-Id",
+				Image: &plans.Image{
+					Repository: "test-image",
+					Tag:        "test-version",
+				},
+				Name: "test-Name",
+			},
+		},
+		Inputs:  dummySliceAssignment(inputs),
+		Outputs: dummySliceAssignment(outputs),
+		Log:     nil,
+	}
+}
+
+func dummyRunWithLog(runId string, knitId string, inputs map[string]string, outputs map[string]string) runs.Detail {
+	return runs.Detail{
+		Summary: runs.Summary{
+			RunId:  runId,
+			Status: "done",
+			Plan: plans.Summary{
+				PlanId: "test-Id",
+				Image: &plans.Image{
+					Repository: "test-image",
+					Tag:        "test-version",
+				},
+				Name: "test-Name",
+			},
+		},
+		Inputs:  dummySliceAssignment(inputs),
+		Outputs: dummySliceAssignment(outputs),
+		Log: &runs.LogSummary{
+			LogPoint: plans.LogPoint{
+				Tags: []tags.Tag{
+					{Key: "type", Value: "log"},
+					{Key: "format", Value: "jsonl"},
+				},
+			},
+			KnitId: knitId,
+		},
+	}
+}
+
+func dummyFailedRunWithLog(runId string, knitId string, inputs map[string]string, outputs map[string]string) runs.Detail {
+	return runs.Detail{
+		Summary: runs.Summary{
+			RunId:  runId,
+			Status: "failed",
+			Plan: plans.Summary{
+				PlanId: "test-Id",
+				Image: &plans.Image{
+					Repository: "test-image",
+					Tag:        "test-version",
+				},
+				Name: "test-Name",
+			},
+		},
+		Inputs:  dummySliceAssignment(inputs),
+		Outputs: dummySliceAssignment(outputs),
+		Log: &runs.LogSummary{
+			LogPoint: plans.LogPoint{
+				Tags: []tags.Tag{
+					{Key: "type", Value: "log"},
+					{Key: "format", Value: "jsonl"},
+				},
+			},
+			KnitId: knitId,
+		},
+	}
+}
+
+func dummyLogData(knitId string, fromRunId string, toRunIds ...string) data.Detail {
+	return data.Detail{
+		KnitId: knitId,
+		Tags: []tags.Tag{
+			{Key: "type", Value: "log"},
+			{Key: "format", Value: "jsonl"},
+		},
+		Upstream:    dummyAssignedTo(fromRunId),
+		Downstreams: dummySliceAssignedTo(toRunIds...),
+		Nomination:  []data.NominatedBy{},
+	}
+}
+
+func dummyAssignment(knitId string, mountPath string) runs.Assignment {
+	return runs.Assignment{
+		Mountpoint: plans.Mountpoint{
+			Path: mountPath,
+			Tags: []tags.Tag{
+				{Key: "type", Value: "training data"},
+				{Key: "format", Value: "mask"},
+			},
+		},
+		KnitId: knitId,
+	}
+}
+
+func dummySliceAssignment(knitIdToMoutPath map[string]string) []runs.Assignment {
+	slice := []runs.Assignment{}
+	keys := make([]string, 0, len(knitIdToMoutPath))
+	for k := range knitIdToMoutPath {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		element := dummyAssignment(k, knitIdToMoutPath[k])
+		slice = append(slice, element)
+
+	}
+	return slice
+}

--- a/cmd/knit/knitgraph/graph_test.go
+++ b/cmd/knit/knitgraph/graph_test.go
@@ -285,7 +285,6 @@ func TestGenerateDot(t *testing.T) {
 					knitgraph.WithRun(run2),
 					knitgraph.WithData(data1),
 					knitgraph.WithRun(run1),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				ArgKnitId: "data2",
 			},
@@ -340,8 +339,8 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"root#0"[shape=Mdiamond];
 
-	"ddata1" -> "rrun2" [label="/in/1"];
 	"rrun2" -> "ddata2" [label="/out/1"];
+	"ddata1" -> "rrun2" [label="/in/1"];
 	"rrun1" -> "ddata1" [label="/upload"];
 	"root#0" -> "rrun1";
 
@@ -469,7 +468,6 @@ func TestGenerateDot(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1, data2, log),
 					knitgraph.WithRun(run1, run2),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				ArgKnitId: "data1",
 			},
@@ -536,11 +534,11 @@ func TestGenerateDot(t *testing.T) {
 	];
 	"root#0"[shape=Mdiamond];
 
-	"ddata1" -> "rrun2" [label="/in/1"];
 	"rrun1" -> "ddata1" [label="/upload"];
+	"root#0" -> "rrun1";
+	"ddata1" -> "rrun2" [label="/in/1"];
 	"rrun2" -> "ddata2" [label="/out/1"];
 	"rrun2" -> "dlog" [label="(log)"];
-	"root#0" -> "rrun1";
 
 }`,
 					try.To(rfctime.ParseRFC3339DateTime("2024-04-01T21:34:56+09:00")).OrFatal(t).
@@ -879,11 +877,11 @@ func TestGenerateDot(t *testing.T) {
 	];
 
 	"ddata1" -> "rrun1" [label="/in/1"];
+	"rrun1" -> "ddata2" [label="/out/1"];
+	"rrun1" -> "ddata3" [label="/out/2"];
 	"ddata2" -> "rrun2" [label="/in/2"];
 	"ddata3" -> "rrun3" [label="/in/4"];
 	"ddata4" -> "rrun2" [label="/in/3"];
-	"rrun1" -> "ddata2" [label="/out/1"];
-	"rrun1" -> "ddata3" [label="/out/2"];
 	"rrun2" -> "ddata5" [label="/out/3"];
 	"rrun3" -> "ddata6" [label="/out/4"];
 

--- a/cmd/knit/knitgraph/nodes.go
+++ b/cmd/knit/knitgraph/nodes.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/opst/knitfab-api-types/data"
 	"github.com/opst/knitfab-api-types/misc/rfctime"
+	"github.com/opst/knitfab-api-types/plans"
 	"github.com/opst/knitfab-api-types/runs"
 	"github.com/opst/knitfab-api-types/tags"
 	"github.com/opst/knitfab/pkg/domain"
 	"github.com/opst/knitfab/pkg/utils/cmp"
+	"github.com/opst/knitfab/pkg/utils/maps"
 )
 
 type RootNode struct {
@@ -32,9 +34,224 @@ func (r *RootNode) ToDot(w io.Writer) error {
 	return err
 }
 
+type InputNode struct {
+	NodeId NodeId
+	plans.Input
+}
+
+func (in *InputNode) Equal(o *InputNode) bool {
+	return in.NodeId == o.NodeId && in.Equal(o)
+}
+
+func (in *InputNode) ToDot(w io.Writer) error {
+	_, err := fmt.Fprintf(
+		w,
+		`		"%s"[shape=point, color="#1c9930"];
+`,
+		in.NodeId,
+	)
+
+	return err
+}
+
+type OutputNode struct {
+	NodeId NodeId
+	plans.Output
+}
+
+func (o *OutputNode) Equal(oo *OutputNode) bool {
+	return o.NodeId == oo.NodeId && o.Equal(oo)
+}
+
+func (o *OutputNode) ToDot(w io.Writer) error {
+	_, err := fmt.Fprintf(
+		w,
+		`		"%s"[shape=point, color="#1c9930"];
+`,
+		o.NodeId,
+	)
+
+	return err
+}
+
+type PlanLogNode struct {
+	NodeId NodeId
+	plans.Log
+}
+
+func (l *PlanLogNode) Equal(o *PlanLogNode) bool {
+	if (o == nil) != (l == nil) {
+		return false
+	}
+	if l == nil {
+		return true
+	}
+	return l.NodeId == o.NodeId && l.Equal(o)
+}
+
+func (l *PlanLogNode) ToDot(w io.Writer) error {
+	_, err := fmt.Fprintf(
+		w,
+		`		"%s"[shape=point, color="#1c9930"];
+`,
+		l.NodeId,
+	)
+
+	return err
+}
+
+type PlanNode struct {
+	NodeId NodeId
+	plans.Detail
+
+	InputNodes  maps.Map[string, InputNode]
+	OutputNodes maps.Map[string, OutputNode]
+	LogNode     *PlanLogNode
+
+	Emphasize bool
+}
+
+func (p *PlanNode) Equal(o *PlanNode) bool {
+	if (o == nil) != (p == nil) {
+		return false
+	}
+	if p == nil {
+		return true
+	}
+	return p.NodeId == o.NodeId &&
+		p.Equal(o) &&
+		cmp.MapEqWith(p.InputNodes.ToMap(), o.InputNodes.ToMap(), func(a, b InputNode) bool { return a.Equal(&b) }) &&
+		cmp.MapEqWith(p.OutputNodes.ToMap(), o.OutputNodes.ToMap(), func(a, b OutputNode) bool { return a.Equal(&b) }) &&
+		p.LogNode.Equal(o.LogNode) &&
+		p.Emphasize == o.Emphasize
+}
+
+func (p *PlanNode) ToDot(w io.Writer) error {
+	title := ""
+	if p.Image != nil {
+		title = "image = " + p.Image.String()
+	} else if p.Name != "" {
+		title = p.Name
+	}
+
+	annotations := []string{}
+	for _, a := range p.Annotations {
+		annotations = append(annotations, fmt.Sprintf(`<B>%s</B>=%s`, html.EscapeString(a.Key), html.EscapeString(a.Value)))
+	}
+	{
+		_, err := fmt.Fprintf(w, `	subgraph {
+`)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, in := range p.InputNodes.Iter() {
+		if err := in.ToDot(w); err != nil {
+			return err
+		}
+
+		_, err := fmt.Fprintf(
+			w,
+			`		"%s" -> "%s" [label="%s"];
+`,
+			in.NodeId, p.NodeId, in.Input.Mountpoint.Path,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	{
+		idBgColor := "#FFFFFF"
+		if p.Emphasize {
+			idBgColor = "#EDD9B4"
+		}
+		_, err := fmt.Fprintf(
+			w,
+			`		"%s"[
+			shape=none
+			color="#DAA520"
+			label=<
+				<TABLE CELLSPACING="0">
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="%s">id: %s</TD></TR>
+					<TR><TD COLSPAN="2">%s</TD></TR>
+					<TR><TD COLSPAN="2">%s</TD></TR>
+				</TABLE>
+			>
+		];
+`,
+			p.NodeId,
+			idBgColor, p.PlanId,
+			html.EscapeString(title),
+			strings.Join(annotations, "<BR/>"),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, out := range p.OutputNodes.Iter() {
+		if err := out.ToDot(w); err != nil {
+			return err
+		}
+
+		_, err := fmt.Fprintf(
+			w,
+			`		"%s" -> "%s" [label="%s"];
+`,
+			p.NodeId, out.NodeId, out.Output.Mountpoint.Path,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	if p.LogNode != nil {
+		if err := p.LogNode.ToDot(w); err != nil {
+			return err
+		}
+
+		_, err := fmt.Fprintf(
+			w,
+			`		"%s" -> "%s" [label="(log)"];
+`,
+			p.NodeId, p.LogNode.NodeId,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	{
+		_, err := fmt.Fprintf(
+			w,
+			`	}
+`,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type RunNode struct {
 	NodeId NodeId
 	runs.Detail
+
+	Emphasize bool
+}
+
+func (r *RunNode) Equal(o *RunNode) bool {
+	if (o == nil) != (r == nil) {
+		return false
+	}
+	if r == nil {
+		return true
+	}
+	return r.NodeId == o.NodeId && r.Equal(o) && r.Emphasize == o.Emphasize
 }
 
 func (r *RunNode) ToDot(w io.Writer) error {
@@ -55,14 +272,19 @@ func (r *RunNode) ToDot(w io.Writer) error {
 		status = fmt.Sprintf(`<FONT COLOR="red"><B>%s</B></FONT>`, status)
 	}
 
+	idBgColor := "#FFFFFF"
+	if r.Emphasize {
+		idBgColor = "#FFD580"
+	}
+
 	_, err := fmt.Fprintf(
 		w,
 		`	"%s"[
 		shape=none
-		color=orange
+		color="#FFA500"
 		label=<
 			<TABLE CELLSPACING="0">
-				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD>%s</TD><TD>id: %s</TD></TR>
+				<TR><TD BGCOLOR="#FFA500"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD>%s</TD><TD BGCOLOR="%s">id: %s</TD></TR>
 				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
 				<TR><TD COLSPAN="3">%s</TD></TR>
 			</TABLE>
@@ -70,8 +292,7 @@ func (r *RunNode) ToDot(w io.Writer) error {
 	];
 `,
 		r.NodeId,
-		status,
-		html.EscapeString(r.RunId),
+		status, idBgColor, html.EscapeString(r.RunId),
 		html.EscapeString(r.UpdatedAt.Time().Local().Format(rfctime.RFC3339DateTimeFormat)),
 		html.EscapeString(title),
 	)
@@ -81,14 +302,16 @@ func (r *RunNode) ToDot(w io.Writer) error {
 type DataNode struct {
 	NodeId NodeId
 	data.Detail
+	Emphasize bool
 }
 
 func (d *DataNode) Equal(o *DataNode) bool {
 	return d.KnitId == o.KnitId &&
-		cmp.SliceContentEqWith(d.Tags, o.Tags, tags.Tag.Equal)
+		d.Detail.Equal(o.Detail) &&
+		d.Emphasize == o.Emphasize
 }
 
-func (d *DataNode) ToDot(w io.Writer, isArgKnitId bool) error {
+func (d *DataNode) ToDot(w io.Writer) error {
 	knitId := d.KnitId
 
 	systemtag := []string{}
@@ -126,7 +349,10 @@ func (d *DataNode) ToDot(w io.Writer, isArgKnitId bool) error {
 	}
 
 	//The background color of the data node that is the argument gets highlighted from the others.
-	bgColor := map[bool]string{true: "#d4ecc6", false: "#FFFFFF"}[isArgKnitId]
+	idBgColor := "#FFFFFF"
+	if d.Emphasize {
+		idBgColor = "#d4ecc6"
+	}
 	_, err := fmt.Fprintf(
 		w,
 		`	"%s"[
@@ -142,7 +368,7 @@ func (d *DataNode) ToDot(w io.Writer, isArgKnitId bool) error {
 	];
 `,
 		d.NodeId,
-		bgColor,
+		idBgColor,
 		html.EscapeString(knitId),
 		subheader,
 		strings.Join(userTags, "<BR/>"),

--- a/cmd/knit/knitgraph/nodes.go
+++ b/cmd/knit/knitgraph/nodes.go
@@ -1,0 +1,152 @@
+package knitgraph
+
+import (
+	"fmt"
+	"html"
+	"io"
+	"strings"
+
+	"github.com/opst/knitfab-api-types/data"
+	"github.com/opst/knitfab-api-types/misc/rfctime"
+	"github.com/opst/knitfab-api-types/runs"
+	"github.com/opst/knitfab-api-types/tags"
+	"github.com/opst/knitfab/pkg/domain"
+	"github.com/opst/knitfab/pkg/utils/cmp"
+)
+
+type RootNode struct {
+	NodeId NodeId
+}
+
+func (r *RootNode) Equal(o *RootNode) bool {
+	return r.NodeId == o.NodeId
+}
+
+func (r *RootNode) ToDot(w io.Writer) error {
+	_, err := fmt.Fprintf(
+		w,
+		`	"%s"[shape=Mdiamond];
+`,
+		r.NodeId,
+	)
+	return err
+}
+
+type RunNode struct {
+	NodeId NodeId
+	runs.Detail
+}
+
+func (r *RunNode) ToDot(w io.Writer) error {
+	title := ""
+	if r.Plan.Image != nil {
+		title = "image = " + r.Plan.Image.String()
+	} else if r.Plan.Name != "" {
+		title = r.Plan.Name
+	}
+
+	status := html.EscapeString(r.Status)
+	switch domain.KnitRunStatus(r.Status) {
+	case domain.Deactivated:
+		status = fmt.Sprintf(`<FONT COLOR="gray"><B>%s</B></FONT>`, status)
+	case domain.Completing, domain.Done:
+		status = fmt.Sprintf(`<FONT COLOR="#007700"><B>%s</B></FONT>`, status)
+	case domain.Aborting, domain.Failed:
+		status = fmt.Sprintf(`<FONT COLOR="red"><B>%s</B></FONT>`, status)
+	}
+
+	_, err := fmt.Fprintf(
+		w,
+		`	"%s"[
+		shape=none
+		color=orange
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="orange"><FONT COLOR="#FFFFFF"><B>Run</B></FONT></TD><TD>%s</TD><TD>id: %s</TD></TR>
+				<TR><TD COLSPAN="3"><FONT POINT-SIZE="8">last updated: %s</FONT></TD></TR>
+				<TR><TD COLSPAN="3">%s</TD></TR>
+			</TABLE>
+		>
+	];
+`,
+		r.NodeId,
+		status,
+		html.EscapeString(r.RunId),
+		html.EscapeString(r.UpdatedAt.Time().Local().Format(rfctime.RFC3339DateTimeFormat)),
+		html.EscapeString(title),
+	)
+	return err
+}
+
+type DataNode struct {
+	NodeId NodeId
+	data.Detail
+}
+
+func (d *DataNode) Equal(o *DataNode) bool {
+	return d.KnitId == o.KnitId &&
+		cmp.SliceContentEqWith(d.Tags, o.Tags, tags.Tag.Equal)
+}
+
+func (d *DataNode) ToDot(w io.Writer, isArgKnitId bool) error {
+	knitId := d.KnitId
+
+	systemtag := []string{}
+	userTags := []string{}
+	for _, tag := range d.Tags {
+		switch tag.Key {
+		case domain.KeyKnitTimestamp:
+			tsp, err := rfctime.ParseRFC3339DateTime(tag.Value)
+			if err != nil {
+				return err
+			}
+			systemtag = append(
+				systemtag,
+				html.EscapeString(tsp.Time().Local().Format(rfctime.RFC3339DateTimeFormat)),
+			)
+			continue
+		case domain.KeyKnitTransient:
+			systemtag = append(systemtag, html.EscapeString(tag.String()))
+			continue
+		case tags.KeyKnitId:
+			continue
+		}
+
+		userTags = append(
+			userTags,
+			fmt.Sprintf(`<B>%s</B>:%s`, html.EscapeString(tag.Key), html.EscapeString(tag.Value)),
+		)
+	}
+	subheader := ""
+	if len(systemtag) != 0 {
+		subheader = fmt.Sprintf(
+			`<TR><TD COLSPAN="2"><FONT POINT-SIZE="8">%s</FONT></TD></TR>`,
+			strings.Join(systemtag, " | "),
+		)
+	}
+
+	//The background color of the data node that is the argument gets highlighted from the others.
+	bgColor := map[bool]string{true: "#d4ecc6", false: "#FFFFFF"}[isArgKnitId]
+	_, err := fmt.Fprintf(
+		w,
+		`	"%s"[
+		shape=none
+		color="#1c9930"
+		label=<
+			<TABLE CELLSPACING="0">
+				<TR><TD BGCOLOR="#1c9930"><FONT COLOR="#FFFFFF"><B>Data</B></FONT></TD><TD BGCOLOR="%s">knit#id: %s</TD></TR>
+				%s
+				<TR><TD COLSPAN="2">%s</TD></TR>
+			</TABLE>
+		>
+	];
+`,
+		d.NodeId,
+		bgColor,
+		html.EscapeString(knitId),
+		subheader,
+		strings.Join(userTags, "<BR/>"),
+	)
+	return err
+
+}

--- a/cmd/knit/knitgraph/nodes.go
+++ b/cmd/knit/knitgraph/nodes.go
@@ -66,7 +66,7 @@ func (o *OutputNode) Equal(oo *OutputNode) bool {
 func (o *OutputNode) ToDot(w io.Writer) error {
 	_, err := fmt.Fprintf(
 		w,
-		`		"%s"[shape=point, color="#1c9930"];
+		`		"%s"[shape=point, color="#1c9930", margin="0,0"];
 `,
 		o.NodeId,
 	)
@@ -92,7 +92,7 @@ func (l *PlanLogNode) Equal(o *PlanLogNode) bool {
 func (l *PlanLogNode) ToDot(w io.Writer) error {
 	_, err := fmt.Fprintf(
 		w,
-		`		"%s"[shape=point, color="#1c9930"];
+		`		"%s"[shape=point, color="#1c9930", margin="0,0"];
 `,
 		l.NodeId,
 	)
@@ -139,7 +139,7 @@ func (p *PlanNode) ToDot(w io.Writer) error {
 		annotations = append(annotations, fmt.Sprintf(`<B>%s</B>=%s`, html.EscapeString(a.Key), html.EscapeString(a.Value)))
 	}
 	{
-		_, err := fmt.Fprintf(w, `	subgraph {
+		_, err := fmt.Fprintf(w, `	subgraph { cluster=true; style=solid; penwidth=0.3; color="#DAA520"; margin="0,0";
 `)
 		if err != nil {
 			return err
@@ -153,7 +153,7 @@ func (p *PlanNode) ToDot(w io.Writer) error {
 
 		_, err := fmt.Fprintf(
 			w,
-			`		"%s" -> "%s" [label="%s"];
+			`		"%s" -> "%s" [label="%s", weight=10, penwidth=0.3];
 `,
 			in.NodeId, p.NodeId, in.Input.Mountpoint.Path,
 		)
@@ -167,6 +167,14 @@ func (p *PlanNode) ToDot(w io.Writer) error {
 		if p.Emphasize {
 			idBgColor = "#EDD9B4"
 		}
+
+		activeColor := "#007700"
+		activeness := "active"
+		if !p.Active {
+			activeColor = "gray"
+			activeness = "inactive"
+		}
+
 		_, err := fmt.Fprintf(
 			w,
 			`		"%s"[
@@ -174,15 +182,15 @@ func (p *PlanNode) ToDot(w io.Writer) error {
 			color="#DAA520"
 			label=<
 				<TABLE CELLSPACING="0">
-					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD BGCOLOR="%s">id: %s</TD></TR>
-					<TR><TD COLSPAN="2">%s</TD></TR>
-					<TR><TD COLSPAN="2">%s</TD></TR>
+					<TR><TD BGCOLOR="#DAA520"><FONT COLOR="#FFFFFF"><B>Plan</B></FONT></TD><TD><FONT COLOR="%s">%s</FONT></TD><TD BGCOLOR="%s">id: %s</TD></TR>
+					<TR><TD COLSPAN="3">%s</TD></TR>
+					<TR><TD COLSPAN="3">%s</TD></TR>
 				</TABLE>
 			>
 		];
 `,
 			p.NodeId,
-			idBgColor, p.PlanId,
+			activeColor, activeness, idBgColor, p.PlanId,
 			html.EscapeString(title),
 			strings.Join(annotations, "<BR/>"),
 		)
@@ -198,7 +206,7 @@ func (p *PlanNode) ToDot(w io.Writer) error {
 
 		_, err := fmt.Fprintf(
 			w,
-			`		"%s" -> "%s" [label="%s"];
+			`		"%s" -> "%s" [label="%s", weight=10, penwidth=0.3];
 `,
 			p.NodeId, out.NodeId, out.Output.Mountpoint.Path,
 		)
@@ -214,7 +222,7 @@ func (p *PlanNode) ToDot(w io.Writer) error {
 
 		_, err := fmt.Fprintf(
 			w,
-			`		"%s" -> "%s" [label="(log)"];
+			`		"%s" -> "%s" [label="(log)", weight=10, penwidth=0.3];
 `,
 			p.NodeId, p.LogNode.NodeId,
 		)

--- a/cmd/knit/subcommands/data/lineage/command_test.go
+++ b/cmd/knit/subcommands/data/lineage/command_test.go
@@ -25,10 +25,8 @@ import (
 	"github.com/opst/knitfab/pkg/domain"
 	"github.com/opst/knitfab/pkg/utils/args"
 	"github.com/opst/knitfab/pkg/utils/cmp"
-	"github.com/opst/knitfab/pkg/utils/maps"
 	"github.com/opst/knitfab/pkg/utils/pointer"
 	"github.com/opst/knitfab/pkg/utils/try"
-	"github.com/opst/knitfab/pkg/utils/tuple"
 )
 
 func TestLineageCommand(t *testing.T) {
@@ -246,7 +244,7 @@ func TestTraceDownStream(t *testing.T) {
 	}
 
 	type Then struct {
-		Graph knitgraph.DirectedGraph
+		Graph *knitgraph.DirectedGraph
 		Err   error
 	}
 
@@ -354,18 +352,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
-					RootNodes:     []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2),
+					knitgraph.WithRun(run1),
+				),
 				Err: nil,
 			},
 		))
@@ -379,18 +369,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
-					RootNodes:     []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2),
+					knitgraph.WithRun(run1),
+				),
 				Err: nil,
 			},
 		))
@@ -414,27 +396,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1, run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}},
-						"data2": {{ToId: "run2", Label: "in/2"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data2", Label: "out/1"}},
-						"run2": {{ToId: "data3", Label: "out/2"}, {ToId: "data4", Label: "out/3"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run2),
+				),
 				Err: nil,
 			},
 		))
@@ -448,18 +413,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
-					RootNodes:     []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2),
+					knitgraph.WithRun(run1),
+				),
 				Err: nil,
 			},
 		),
@@ -483,19 +440,10 @@ func TestTraceDownStream(t *testing.T) {
 				FindDataReturns: [][]data.Detail{{data1}, {data2}, {data3}},
 				GetRunReturns:   []runs.Detail{run1}},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run1", Label: "in/2"}}},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data3", Label: "out/1"}}},
-					RootNodes:     []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3),
+					knitgraph.WithRun(run1),
+				),
 				Err: nil,
 			},
 		))
@@ -521,27 +469,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1, run2, run3},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run2", Label: "in/2"}},
-						"data2": {{ToId: "run3", Label: "in/3"}}, "data3": {{ToId: "run3", Label: "in/4"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data2", Label: "out/1"}}, "run2": {{ToId: "data3", Label: "out/2"}}, "run3": {{ToId: "data4", Label: "out/3"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run2, run3),
+				),
 				Err: nil,
 			},
 		))
@@ -568,26 +499,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1, run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run1", Label: "in/2"}, {ToId: "run2", Label: "in/3"}},
-						"data3": {{ToId: "run2", Label: "in/4"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data3", Label: "out/1"}}, "run2": {{ToId: "data4", Label: "out/2"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run2),
+				),
 				Err: nil,
 			},
 		))
@@ -618,23 +533,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1, run3},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run3", Label: "in/2"}}, "data3": {{ToId: "run3", Label: "in/4"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}, "run3": {{ToId: "data4", Label: "out/3"}}},
-					RootNodes:    []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run3),
+				),
 				Err: nil,
 			},
 		))
@@ -648,27 +550,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1, run3, run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run3", Label: "in/2"}},
-						"data2": {{ToId: "run2", Label: "in/3"}}, "data3": {{ToId: "run3", Label: "in/4"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data2", Label: "out/1"}}, "run2": {{ToId: "data3", Label: "out/2"}}, "run3": {{ToId: "data4", Label: "out/3"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run3, run2),
+				),
 				Err: nil,
 			},
 		))
@@ -682,31 +567,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1, run3, run2, run4},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-						tuple.PairOf("data5", toDataNode(data5)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run3", Label: "in/2"}},
-						"data2": {{ToId: "run2", Label: "in/3"}},
-						"data3": {{ToId: "run3", Label: "in/4"}, {ToId: "run4", Label: "in/5"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data2", Label: "out/1"}}, "run2": {{ToId: "data3", Label: "out/2"}},
-						"run3": {{ToId: "data4", Label: "out/3"}}, "run4": {{ToId: "data5", Label: "out/4"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4, data5),
+					knitgraph.WithRun(run1, run3, run2, run4),
+				),
 				Err: nil,
 			},
 		))
@@ -727,19 +591,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1, run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run2", Label: "in/2"}}},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
-					RootNodes:     []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2),
+					knitgraph.WithRun(run1, run2),
+				),
 				Err: nil,
 			},
 		))
@@ -763,48 +618,18 @@ func TestTraceDownStream(t *testing.T) {
 			When{
 				RootKnitId: "data1",
 				Depth:      args.NewInfinityDepth(),
-				ArgGraph: &knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data3": {{ToId: "run1", Label: "in/1"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data1", Label: "out/1"}, {ToId: "data2", Label: "out/2"}},
-					},
-					RootNodes: []string{},
-				},
+				ArgGraph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3),
+					knitgraph.WithRun(run1),
+				),
 				FindDataReturns: [][]data.Detail{{data4}},
 				GetRunReturns:   []runs.Detail{run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run2", Label: "in/2"}}, "data2": {{ToId: "run2", Label: "in/3"}},
-						"data3": {{ToId: "run1", Label: "in/1"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data1", Label: "out/1"}, {ToId: "data2", Label: "out/2"}},
-						"run2": {{ToId: "data4", Label: "out/3"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run2),
+				),
 				Err: nil,
 			},
 		))
@@ -834,26 +659,10 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns: []runs.Detail{run1, run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}}, "data3": {{ToId: "run2", Label: "in/2"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data2", Label: "out/1"}, {ToId: "data3", Label: "(log)"}},
-						"run2": {{ToId: "data4", Label: "out/2"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run2),
+				),
 				Err: nil,
 			},
 		))
@@ -925,7 +734,7 @@ func TestTraceUpStream(t *testing.T) {
 	}
 
 	type Then struct {
-		Graph knitgraph.DirectedGraph
+		Graph *knitgraph.DirectedGraph
 		Err   error
 	}
 
@@ -1031,17 +840,11 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "upload"}}},
-					RootNodes:     []string{"run1"},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1),
+					knitgraph.WithRun(run1),
+					knitgraph.WithRoot(run1.RunId),
+				),
 				Err: nil,
 			},
 		))
@@ -1053,17 +856,11 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "upload"}}},
-					RootNodes:     []string{"run1"},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1),
+					knitgraph.WithRun(run1),
+					knitgraph.WithRoot(run1.RunId),
+				),
 				Err: nil,
 			},
 		))
@@ -1083,19 +880,11 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run2, run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}}},
-					RootNodes:     []string{"run1"},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2),
+					knitgraph.WithRun(run1, run2),
+					knitgraph.WithRoot(run1.RunId),
+				),
 				Err: nil,
 			},
 		))
@@ -1107,18 +896,10 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}},
-					EdgesFromRun:  map[string][]knitgraph.Edge{"run2": {{ToId: "data2", Label: "out/1"}}},
-					RootNodes:     []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2),
+					knitgraph.WithRun(run2),
+				),
 				Err: nil,
 			},
 		))
@@ -1141,22 +922,11 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run2, run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}, {ToId: "data3", Label: "out/2"}},
-					},
-					RootNodes: []string{"run1"},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3),
+					knitgraph.WithRun(run1, run2),
+					knitgraph.WithRoot(run1.RunId),
+				),
 				Err: nil,
 			},
 		))
@@ -1181,27 +951,11 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run3, run2, run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run2", Label: "in/1"}}, "data2": {{ToId: "run3", Label: "in/2"}}, "data3": {{ToId: "run3", Label: "in/3"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}, {ToId: "data3", Label: "out/2"}},
-						"run3": {{ToId: "data4", Label: "out/3"}},
-					},
-					RootNodes: []string{"run1"},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run2, run3),
+					knitgraph.WithRoot(run1.RunId),
+				),
 				Err: nil,
 			},
 		))
@@ -1230,23 +984,10 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run4},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run4", Label: "in/3"}}, "data3": {{ToId: "run4", Label: "in/4"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run4": {{ToId: "data4", Label: "out/3"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data3, data4),
+					knitgraph.WithRun(run4),
+				),
 				Err: nil,
 			},
 		))
@@ -1258,27 +999,11 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run4, run1, run3},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
-						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run4", Label: "in/3"}, {ToId: "run3", Label: "in/2"}},
-						"data2": {{ToId: "run3", Label: "in/4"}}, "data3": {{ToId: "run4", Label: "in/4"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run4": {{ToId: "data4", Label: "out/3"}}, "run3": {{ToId: "data3", Label: "out/2"}}, "run1": {{ToId: "data1", Label: "upload"}},
-					},
-					RootNodes: []string{"run1"},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run3, run4),
+					knitgraph.WithRoot(run1.RunId),
+				),
 				Err: nil,
 			},
 		))
@@ -1291,29 +1016,11 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run4, run1, run3, run2},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
-						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run4", Label: "in/3"}, {ToId: "run3", Label: "in/2"}, {ToId: "run2", Label: "in/1"}},
-						"data2": {{ToId: "run3", Label: "in/4"}}, "data3": {{ToId: "run4", Label: "in/4"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run4": {{ToId: "data4", Label: "out/3"}}, "run3": {{ToId: "data3", Label: "out/2"}}, "run1": {{ToId: "data1", Label: "upload"}},
-						"run2": {{ToId: "data2", Label: "out/1"}},
-					},
-					RootNodes: []string{"run1"},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4),
+					knitgraph.WithRun(run1, run3, run2, run4),
+					knitgraph.WithRoot(run1.RunId),
+				),
 				Err: nil,
 			},
 		))
@@ -1343,27 +1050,10 @@ func TestTraceUpStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run2, run1},
 			},
 			Then{
-				Graph: knitgraph.DirectedGraph{
-					DataNodes: maps.NewOrderedMap(
-						tuple.PairOf("data1", toDataNode(data1)),
-						tuple.PairOf("data2", toDataNode(data2)),
-						tuple.PairOf("data3", toDataNode(data3)),
-						tuple.PairOf("data4", toDataNode(data4)),
-						tuple.PairOf("data2", toDataNode(data5)),
-					),
-					RunNodes: maps.NewOrderedMap(
-						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
-						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
-					),
-					EdgesFromData: map[string][]knitgraph.Edge{
-						"data1": {{ToId: "run1", Label: "in/1"}}, "data3": {{ToId: "run2", Label: "in/2"}},
-					},
-					EdgesFromRun: map[string][]knitgraph.Edge{
-						"run1": {{ToId: "data3", Label: "out/1"}, {ToId: "data2", Label: "(log)"}},
-						"run2": {{ToId: "data4", Label: "out/2"}, {ToId: "data5", Label: "(log)"}},
-					},
-					RootNodes: []string{},
-				},
+				Graph: knitgraph.NewDirectedGraph(
+					knitgraph.WithData(data1, data2, data3, data4, data5),
+					knitgraph.WithRun(run1, run2),
+				),
 				Err: nil,
 			},
 		))
@@ -1427,18 +1117,7 @@ func TestTraceUpStream(t *testing.T) {
 }
 
 func toDataNode(data data.Detail) knitgraph.DataNode {
-	return knitgraph.DataNode{
-		KnitId:    data.KnitId,
-		Tags:      data.Tags,
-		FromRunId: data.Upstream.Run.RunId,
-		ToRunIds: func() []string {
-			ids := []string{}
-			for _, downstream := range data.Downstreams {
-				ids = append(ids, downstream.Run.RunId)
-			}
-			return ids
-		}(),
-	}
+	return knitgraph.DataNode{Detail: data}
 }
 
 func dummyCreatedFrom(runId string) data.CreatedFrom {

--- a/cmd/knit/subcommands/data/lineage/command_test.go
+++ b/cmd/knit/subcommands/data/lineage/command_test.go
@@ -301,33 +301,13 @@ func TestTraceDownStream(t *testing.T) {
 					graph.RunNodes, then.Graph.RunNodes,
 				)
 			}
-			if !cmp.MapEqWith(
-				graph.EdgesFromData,
-				then.Graph.EdgesFromData,
-				func(a []knitgraph.Edge, b []knitgraph.Edge) bool {
-					return cmp.SliceContentEq(a, b)
-				},
-			) {
+			if !cmp.SliceContentEq(graph.Edges, then.Graph.Edges) {
 				t.Errorf(
-					"EdgesFromData is not equal (actual,expected): %v,%v",
-					graph.EdgesFromData, then.Graph.EdgesFromData,
+					"Edges is not equal (actual,expected): %v,%v",
+					graph.Edges, then.Graph.Edges,
 				)
 			}
-			if !cmp.MapEqWith(
-				graph.EdgesFromRun,
-				then.Graph.EdgesFromRun,
-				func(a []knitgraph.Edge, b []knitgraph.Edge) bool {
-					return cmp.SliceContentEq(a, b)
-				},
-			) {
-				t.Errorf(
-					"EdgesFromRun is not equal (actual,expected): %v,%v",
-					graph.EdgesFromRun, then.Graph.EdgesFromRun,
-				)
-			}
-			if !cmp.SliceContentEq(
-				graph.RootNodes, then.Graph.RootNodes,
-			) {
+			if !cmp.SliceContentEq(graph.RootNodes, then.Graph.RootNodes) {
 				t.Errorf(
 					"RootNodes is not equal (actual,expected): %v,%v",
 					graph.RootNodes, then.Graph.RootNodes,
@@ -792,28 +772,10 @@ func TestTraceUpStream(t *testing.T) {
 					graph.RunNodes, then.Graph.RunNodes,
 				)
 			}
-			if !cmp.MapEqWith(
-				graph.EdgesFromData,
-				then.Graph.EdgesFromData,
-				func(a []knitgraph.Edge, b []knitgraph.Edge) bool {
-					return cmp.SliceContentEq(a, b)
-				},
-			) {
+			if !cmp.SliceContentEq(graph.Edges, then.Graph.Edges) {
 				t.Errorf(
 					"EdgesFromData is not equal (actual,expected): %v,%v",
-					graph.EdgesFromData, then.Graph.EdgesFromData,
-				)
-			}
-			if !cmp.MapEqWith(
-				graph.EdgesFromRun,
-				then.Graph.EdgesFromRun,
-				func(a []knitgraph.Edge, b []knitgraph.Edge) bool {
-					return cmp.SliceContentEq(a, b)
-				},
-			) {
-				t.Errorf(
-					"EdgesFromRun is not equal (actual,expected): %v,%v",
-					graph.EdgesFromRun, then.Graph.EdgesFromRun,
+					graph.Edges, then.Graph.Edges,
 				)
 			}
 			if !cmp.SliceContentEq(
@@ -843,7 +805,6 @@ func TestTraceUpStream(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1),
 					knitgraph.WithRun(run1),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				Err: nil,
 			},
@@ -859,7 +820,6 @@ func TestTraceUpStream(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1),
 					knitgraph.WithRun(run1),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				Err: nil,
 			},
@@ -883,7 +843,6 @@ func TestTraceUpStream(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1, data2),
 					knitgraph.WithRun(run1, run2),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				Err: nil,
 			},
@@ -925,7 +884,6 @@ func TestTraceUpStream(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1, data2, data3),
 					knitgraph.WithRun(run1, run2),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				Err: nil,
 			},
@@ -954,7 +912,6 @@ func TestTraceUpStream(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1, data2, data3, data4),
 					knitgraph.WithRun(run1, run2, run3),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				Err: nil,
 			},
@@ -1002,7 +959,6 @@ func TestTraceUpStream(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1, data2, data3, data4),
 					knitgraph.WithRun(run1, run3, run4),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				Err: nil,
 			},
@@ -1019,7 +975,6 @@ func TestTraceUpStream(t *testing.T) {
 				Graph: knitgraph.NewDirectedGraph(
 					knitgraph.WithData(data1, data2, data3, data4),
 					knitgraph.WithRun(run1, run3, run2, run4),
-					knitgraph.WithRoot(run1.RunId),
 				),
 				Err: nil,
 			},

--- a/cmd/knit/subcommands/data/lineage/command_test.go
+++ b/cmd/knit/subcommands/data/lineage/command_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/opst/knitfab/pkg/domain"
 	"github.com/opst/knitfab/pkg/utils/args"
 	"github.com/opst/knitfab/pkg/utils/cmp"
+	"github.com/opst/knitfab/pkg/utils/maps"
 	"github.com/opst/knitfab/pkg/utils/pointer"
 	"github.com/opst/knitfab/pkg/utils/try"
+	"github.com/opst/knitfab/pkg/utils/tuple"
 )
 
 func TestLineageCommand(t *testing.T) {
@@ -282,8 +284,8 @@ func TestTraceDownStream(t *testing.T) {
 			}
 
 			if !cmp.MapEqWith(
-				graph.DataNodes,
-				then.Graph.DataNodes,
+				graph.DataNodes.ToMap(),
+				then.Graph.DataNodes.ToMap(),
 				func(a, b knitgraph.DataNode) bool { return a.Equal(&b) },
 			) {
 				t.Errorf(
@@ -292,8 +294,8 @@ func TestTraceDownStream(t *testing.T) {
 				)
 			}
 			if !cmp.MapEqWith(
-				graph.RunNodes,
-				then.Graph.RunNodes,
+				graph.RunNodes.ToMap(),
+				then.Graph.RunNodes.ToMap(),
 				func(a, b knitgraph.RunNode) bool { return a.Summary.Equal(b.Summary) },
 			) {
 				t.Errorf(
@@ -353,8 +355,13 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
 					RootNodes:     []string{},
@@ -373,8 +380,13 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
 					RootNodes:     []string{},
@@ -403,14 +415,20 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3),
-						"data4": toDataNode(data4),
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
+					EdgesFromData: map[string][]knitgraph.Edge{
+						"data1": {{ToId: "run1", Label: "in/1"}},
+						"data2": {{ToId: "run2", Label: "in/2"}},
 					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary},
-					},
-					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run2", Label: "in/2"}}},
 					EdgesFromRun: map[string][]knitgraph.Edge{
 						"run1": {{ToId: "data2", Label: "out/1"}},
 						"run2": {{ToId: "data3", Label: "out/2"}, {ToId: "data4", Label: "out/3"}},
@@ -431,8 +449,13 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
 					RootNodes:     []string{},
@@ -461,10 +484,14 @@ func TestTraceDownStream(t *testing.T) {
 				GetRunReturns:   []runs.Detail{run1}},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3),
-					},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run1", Label: "in/2"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data3", Label: "out/1"}}},
 					RootNodes:     []string{},
@@ -495,13 +522,17 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}, "run3": {Summary: run3.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run2", Label: "in/2"}},
 						"data2": {{ToId: "run3", Label: "in/3"}}, "data3": {{ToId: "run3", Label: "in/4"}},
@@ -538,11 +569,16 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run1", Label: "in/2"}, {ToId: "run2", Label: "in/3"}},
 						"data3": {{ToId: "run2", Label: "in/4"}},
@@ -583,11 +619,16 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run3": {Summary: run3.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run3", Label: "in/2"}}, "data3": {{ToId: "run3", Label: "in/4"}},
 					},
@@ -608,13 +649,17 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run3": {Summary: run3.Summary}, "run2": {Summary: run2.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run3", Label: "in/2"}},
 						"data2": {{ToId: "run2", Label: "in/3"}}, "data3": {{ToId: "run3", Label: "in/4"}},
@@ -638,14 +683,19 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3),
-						"data4": toDataNode(data4), "data5": toDataNode(data5),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run3": {Summary: run3.Summary},
-						"run2": {Summary: run2.Summary}, "run4": {Summary: run4.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+						tuple.PairOf("data5", toDataNode(data5)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}, {ToId: "run3", Label: "in/2"}},
 						"data2": {{ToId: "run2", Label: "in/3"}},
@@ -678,8 +728,14 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run1", Label: "in/1"}}, "data2": {{ToId: "run2", Label: "in/2"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data2", Label: "out/1"}}},
 					RootNodes:     []string{},
@@ -708,8 +764,14 @@ func TestTraceDownStream(t *testing.T) {
 				RootKnitId: "data1",
 				Depth:      args.NewInfinityDepth(),
 				ArgGraph: &knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3)},
-					RunNodes:  map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data3": {{ToId: "run1", Label: "in/1"}},
 					},
@@ -723,11 +785,16 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run2", Label: "in/2"}}, "data2": {{ToId: "run2", Label: "in/3"}},
 						"data3": {{ToId: "run1", Label: "in/1"}},
@@ -768,11 +835,16 @@ func TestTraceDownStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}}, "data3": {{ToId: "run2", Label: "in/2"}},
 					},
@@ -892,8 +964,8 @@ func TestTraceUpStream(t *testing.T) {
 			}
 
 			if !cmp.MapEqWith(
-				graph.DataNodes,
-				then.Graph.DataNodes,
+				graph.DataNodes.ToMap(),
+				then.Graph.DataNodes.ToMap(),
 				func(a, b knitgraph.DataNode) bool { return a.Equal(&b) },
 			) {
 				t.Errorf(
@@ -902,8 +974,8 @@ func TestTraceUpStream(t *testing.T) {
 				)
 			}
 			if !cmp.MapEqWith(
-				graph.RunNodes,
-				then.Graph.RunNodes,
+				graph.RunNodes.ToMap(),
+				then.Graph.RunNodes.ToMap(),
 				func(a, b knitgraph.RunNode) bool { return a.Summary.Equal(b.Summary) },
 			) {
 				t.Errorf(
@@ -960,8 +1032,12 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "upload"}}},
 					RootNodes:     []string{"run1"},
@@ -978,8 +1054,12 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes:     map[string]knitgraph.DataNode{"data1": toDataNode(data1)},
-					RunNodes:      map[string]knitgraph.RunNode{"run1": {Summary: run1.Summary}},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "upload"}}},
 					RootNodes:     []string{"run1"},
@@ -1004,12 +1084,14 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}}},
 					RootNodes:     []string{"run1"},
@@ -1026,12 +1108,13 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run2": {Summary: run2.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}},
 					EdgesFromRun:  map[string][]knitgraph.Edge{"run2": {{ToId: "data2", Label: "out/1"}}},
 					RootNodes:     []string{},
@@ -1059,12 +1142,15 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{"data1": {{ToId: "run2", Label: "in/1"}}},
 					EdgesFromRun: map[string][]knitgraph.Edge{
 						"run1": {{ToId: "data1", Label: "upload"}}, "run2": {{ToId: "data2", Label: "out/1"}, {ToId: "data3", Label: "out/2"}},
@@ -1096,13 +1182,17 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2), "data3": toDataNode(data3),
-						"data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary}, "run3": {Summary: run3.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run2", Label: "in/1"}}, "data2": {{ToId: "run3", Label: "in/2"}}, "data3": {{ToId: "run3", Label: "in/3"}},
 					},
@@ -1141,12 +1231,14 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run4": {Summary: run4.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run4", Label: "in/3"}}, "data3": {{ToId: "run4", Label: "in/4"}},
 					},
@@ -1167,13 +1259,17 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run3": {Summary: run3.Summary}, "run4": {Summary: run4.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run4", Label: "in/3"}, {ToId: "run3", Label: "in/2"}},
 						"data2": {{ToId: "run3", Label: "in/4"}}, "data3": {{ToId: "run4", Label: "in/4"}},
@@ -1196,14 +1292,18 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary},
-						"run3": {Summary: run3.Summary}, "run4": {Summary: run4.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+						tuple.PairOf("run3", knitgraph.RunNode{Summary: run3.Summary}),
+						tuple.PairOf("run4", knitgraph.RunNode{Summary: run4.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run4", Label: "in/3"}, {ToId: "run3", Label: "in/2"}, {ToId: "run2", Label: "in/1"}},
 						"data2": {{ToId: "run3", Label: "in/4"}}, "data3": {{ToId: "run4", Label: "in/4"}},
@@ -1244,13 +1344,17 @@ func TestTraceUpStream(t *testing.T) {
 			},
 			Then{
 				Graph: knitgraph.DirectedGraph{
-					DataNodes: map[string]knitgraph.DataNode{
-						"data1": toDataNode(data1), "data2": toDataNode(data2),
-						"data3": toDataNode(data3), "data4": toDataNode(data4), "data5": toDataNode(data5),
-					},
-					RunNodes: map[string]knitgraph.RunNode{
-						"run1": {Summary: run1.Summary}, "run2": {Summary: run2.Summary},
-					},
+					DataNodes: maps.NewOrderedMap(
+						tuple.PairOf("data1", toDataNode(data1)),
+						tuple.PairOf("data2", toDataNode(data2)),
+						tuple.PairOf("data3", toDataNode(data3)),
+						tuple.PairOf("data4", toDataNode(data4)),
+						tuple.PairOf("data2", toDataNode(data5)),
+					),
+					RunNodes: maps.NewOrderedMap(
+						tuple.PairOf("run1", knitgraph.RunNode{Summary: run1.Summary}),
+						tuple.PairOf("run2", knitgraph.RunNode{Summary: run2.Summary}),
+					),
 					EdgesFromData: map[string][]knitgraph.Edge{
 						"data1": {{ToId: "run1", Label: "in/1"}}, "data3": {{ToId: "run2", Label: "in/2"}},
 					},

--- a/cmd/knit/subcommands/plan/command.go
+++ b/cmd/knit/subcommands/plan/command.go
@@ -5,6 +5,7 @@ import (
 	plan_annotate "github.com/opst/knitfab/cmd/knit/subcommands/plan/annotate"
 	plan_apply "github.com/opst/knitfab/cmd/knit/subcommands/plan/apply"
 	plan_find "github.com/opst/knitfab/cmd/knit/subcommands/plan/find"
+	plan_graph "github.com/opst/knitfab/cmd/knit/subcommands/plan/graph"
 	plan_resource "github.com/opst/knitfab/cmd/knit/subcommands/plan/resource"
 	plan_serviceaccount "github.com/opst/knitfab/cmd/knit/subcommands/plan/serviceaccount"
 	plan_show "github.com/opst/knitfab/cmd/knit/subcommands/plan/show"
@@ -54,11 +55,17 @@ func New() (flarc.Command, error) {
 		return nil, err
 	}
 
+	graph, err := plan_graph.New()
+	if err != nil {
+		return nil, err
+	}
+
 	return flarc.NewCommandGroup(
 		"Manipulate Knitfab Plan.",
 		struct{}{},
 		flarc.WithSubcommand("show", show),
 		flarc.WithSubcommand("find", find),
+		flarc.WithSubcommand("graph", graph),
 		flarc.WithSubcommand("template", template),
 		flarc.WithSubcommand("apply", apply),
 		flarc.WithSubcommand("active", active),

--- a/cmd/knit/subcommands/plan/graph/command.go
+++ b/cmd/knit/subcommands/plan/graph/command.go
@@ -1,9 +1,194 @@
 package graph
 
-import "github.com/opst/knitfab/pkg/utils/args"
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/opst/knitfab-api-types/plans"
+	"github.com/opst/knitfab/cmd/knit/env"
+	"github.com/opst/knitfab/cmd/knit/knitgraph"
+	"github.com/opst/knitfab/cmd/knit/rest"
+	"github.com/opst/knitfab/cmd/knit/subcommands/common"
+	"github.com/opst/knitfab/pkg/utils/args"
+	"github.com/opst/knitfab/pkg/utils/nils"
+	"github.com/opst/knitfab/pkg/utils/pointer"
+	"github.com/youta-t/flarc"
+)
 
 type Flag struct {
-	Upstream   bool        `flag:"upstream" alias:"u" help:"Trace the upstream of the specified Plan."`
-	Downstream bool        `flag:"downstream" alias:"d" help:"Trace the downstream of the specified Plan."`
+	Upstream   *bool       `flag:"upstream" alias:"u" help:"Trace the upstream of the specified Plan."`
+	Downstream *bool       `flag:"downstream" alias:"d" help:"Trace the downstream of the specified Plan."`
 	Numbers    *args.Depth `flag:"numbers" alias:"n" help:"Trace up to the specified depth. Trace to the upstream-most/downstream-most if 'all' is specified.,metavar=number of depth"`
+}
+
+const ARG_PLANID = "PLAN_ID"
+
+func New() (flarc.Command, error) {
+	return flarc.NewCommand(
+		"Output a pipeline graph of Plans in a dot format.",
+		Flag{
+			Upstream:   nil,
+			Downstream: nil,
+			Numbers:    pointer.Ref(args.NewDepth(3)),
+		},
+		flarc.Args{
+			{
+				Name: ARG_PLANID, Required: true,
+				Help: "The ID of the starting Plan to trace.",
+			},
+		},
+		common.NewTask(Task(MakeGraph)),
+	)
+}
+
+func Task(makeGraph MakeGraphFunc) common.Task[Flag] {
+	return func(
+		ctx context.Context,
+		logger *log.Logger,
+		knitEnv env.KnitEnv,
+		client rest.KnitClient,
+		cl flarc.Commandline[Flag],
+		params []any,
+	) error {
+		planId := cl.Args()[ARG_PLANID][0]
+		numbers := *cl.Flags().Numbers
+		if numbers.IsZero() {
+			return fmt.Errorf("%w: --numbers must be a positive integer or 'all'", flarc.ErrUsage)
+		}
+
+		dir := Direction{}
+		{
+			u := cl.Flags().Upstream
+			d := cl.Flags().Downstream
+
+			if u == nil && d == nil {
+				dir.Upstream = true
+				dir.Downstream = true
+			} else {
+				dir.Upstream = nils.Default(u, false)
+				dir.Downstream = nils.Default(d, false)
+			}
+		}
+
+		graph, err := makeGraph(
+			ctx, client, knitgraph.NewDirectedGraph(), planId, dir, numbers,
+		)
+
+		if err != nil {
+			return err
+		}
+
+		return graph.GenerateDot(cl.Stdout())
+	}
+}
+
+type Direction struct {
+	Upstream   bool
+	Downstream bool
+}
+
+type MakeGraphFunc func(
+	ctx context.Context,
+	client rest.KnitClient,
+	graph *knitgraph.DirectedGraph,
+	planId string,
+	dir Direction,
+	maxDepth args.Depth,
+) (*knitgraph.DirectedGraph, error)
+
+func MakeGraph(
+	ctx context.Context,
+	client rest.KnitClient,
+	graph *knitgraph.DirectedGraph,
+	planId string,
+	dir Direction,
+	maxDepth args.Depth,
+) (*knitgraph.DirectedGraph, error) {
+
+	p, err := client.GetPlans(ctx, planId)
+	if err != nil {
+		return nil, err
+	}
+	graph.AddPlanNode(p, knitgraph.Emphasize())
+
+	if dir.Upstream {
+		if err := traverse(
+			ctx, client, graph, p, maxDepth,
+			func(p plans.Detail) []string {
+				ret := []string{}
+				for _, in := range p.Inputs {
+					for _, upstream := range in.Upstreams {
+						ret = append(ret, upstream.Plan.PlanId)
+					}
+				}
+				return ret
+			},
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	if dir.Downstream {
+		if err := traverse(
+			ctx, client, graph, p, maxDepth,
+			func(p plans.Detail) []string {
+				ret := []string{}
+				for _, out := range p.Outputs {
+					for _, downstream := range out.Downstreams {
+						ret = append(ret, downstream.Plan.PlanId)
+					}
+				}
+				if log := p.Log; log != nil {
+					for _, downstream := range log.Downstreams {
+						ret = append(ret, downstream.Plan.PlanId)
+					}
+				}
+				return ret
+			},
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return graph, nil
+}
+
+func traverse(
+	ctx context.Context,
+	client rest.KnitClient,
+	graph *knitgraph.DirectedGraph,
+	start plans.Detail,
+	depth args.Depth,
+	next func(plans.Detail) []string,
+) error {
+
+	leaves := []plans.Detail{start}
+
+	for 0 < len(leaves) {
+		if depth.IsZero() {
+			return nil
+		}
+		newLeaves := []plans.Detail{}
+
+		for _, leaf := range leaves {
+			for _, planId := range next(leaf) {
+				if _, ok := graph.PlanNodes.Get(planId); ok {
+					continue
+				}
+
+				p, err := client.GetPlans(ctx, planId)
+				if err != nil {
+					return err
+				}
+				graph.AddPlanNode(p)
+				newLeaves = append(newLeaves, p)
+			}
+		}
+
+		leaves = newLeaves
+		depth = depth.Add(-1)
+	}
+
+	return nil
 }

--- a/cmd/knit/subcommands/plan/graph/command.go
+++ b/cmd/knit/subcommands/plan/graph/command.go
@@ -1,0 +1,9 @@
+package graph
+
+import "github.com/opst/knitfab/pkg/utils/args"
+
+type Flag struct {
+	Upstream   bool        `flag:"upstream" alias:"u" help:"Trace the upstream of the specified Plan."`
+	Downstream bool        `flag:"downstream" alias:"d" help:"Trace the downstream of the specified Plan."`
+	Numbers    *args.Depth `flag:"numbers" alias:"n" help:"Trace up to the specified depth. Trace to the upstream-most/downstream-most if 'all' is specified.,metavar=number of depth"`
+}

--- a/cmd/knit/subcommands/plan/graph/command.go
+++ b/cmd/knit/subcommands/plan/graph/command.go
@@ -26,7 +26,7 @@ const ARG_PLANID = "PLAN_ID"
 
 func New() (flarc.Command, error) {
 	return flarc.NewCommand(
-		"Output a pipeline graph of Plans in a dot format.",
+		"Output a Plan Graph, overview of Plan pipeline, in a dot format.",
 		Flag{
 			Upstream:   nil,
 			Downstream: nil,
@@ -35,10 +35,36 @@ func New() (flarc.Command, error) {
 		flarc.Args{
 			{
 				Name: ARG_PLANID, Required: true,
-				Help: "The ID of the starting Plan to trace.",
+				Help: "The ID of the starting Plan to traverse.",
 			},
 		},
 		common.NewTask(Task(MakeGraph)),
+		flarc.WithDescription(`
+{{ .Command }} outputs a "Plan Graph" in a dot format.
+
+The Plan Graph explains the overview of the specified Plan and its upstream/downstream Plans with the specified depth.
+
+"Plan A is upstream of Plan B" or "Plan B is downstream of Plan A" mean that an output of a Run of Plan A can be an input of Plan B.
+
+The graph is output in a dot format, which can be converted to an image using the dot command.
+
+    {{ .Command }} PLAN_ID | dot -Tpng -o graph.png
+
+By default, the graph includes both upstream and downstream Plans upto 3 Plans away from specified plans.
+
+To restrict the depth of the graph, use the --numbers flag.
+
+	{{ .Command }} PLAN_ID --numbers 2 | dot -Tpng -o graph.png
+
+Or, to traverse unlimitedly, use 'all'.
+
+	{{ .Command }} PLAN_ID --numbers all | dot -Tpng -o graph.png
+
+To traverse only the upstream or downstream Plans, use the --upstream or --downstream flag.
+
+	{{ .Command }} PLAN_ID --upstream | dot -Tpng -o graph.png
+	{{ .Command }} PLAN_ID --downstream | dot -Tpng -o graph.png
+`),
 	)
 }
 

--- a/cmd/knit/subcommands/plan/graph/command_test.go
+++ b/cmd/knit/subcommands/plan/graph/command_test.go
@@ -1,0 +1,951 @@
+package graph_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/opst/knitfab-api-types/plans"
+	kprof "github.com/opst/knitfab/cmd/knit/config/profiles"
+	"github.com/opst/knitfab/cmd/knit/env"
+	"github.com/opst/knitfab/cmd/knit/knitgraph"
+	krst "github.com/opst/knitfab/cmd/knit/rest"
+	krstmock "github.com/opst/knitfab/cmd/knit/rest/mock"
+	"github.com/opst/knitfab/cmd/knit/subcommands/internal/commandline"
+	"github.com/opst/knitfab/cmd/knit/subcommands/logger"
+	"github.com/opst/knitfab/cmd/knit/subcommands/plan/graph"
+	"github.com/opst/knitfab/pkg/utils/args"
+	"github.com/opst/knitfab/pkg/utils/cmp"
+	"github.com/opst/knitfab/pkg/utils/pointer"
+	"github.com/opst/knitfab/pkg/utils/slices"
+	"github.com/opst/knitfab/pkg/utils/try"
+	"github.com/youta-t/flarc"
+)
+
+func TestTask(t *testing.T) {
+
+	type When struct {
+		Flag graph.Flag
+		Args map[string][]string
+		Err  error
+	}
+
+	type Then struct {
+		PlanId        string
+		Dir           graph.Direction
+		MaxDepth      args.Depth
+		taskIsInvoked bool
+		Err           error
+	}
+
+	theory := func(when When, then Then) func(*testing.T) {
+		return func(t *testing.T) {
+			ctx := context.Background()
+
+			logger := logger.Null()
+			profile := &kprof.KnitProfile{
+				ApiRoot: "http://api.knit.invalid/api",
+			}
+			client := try.To(krst.NewClient(profile)).OrFatal(t)
+			fakeCommandline := commandline.MockCommandline[graph.Flag]{
+				Fullname_: "knit plan graph",
+				Args_:     when.Args,
+				Flags_:    when.Flag,
+				Stdout_:   io.Discard,
+				Stderr_:   io.Discard,
+			}
+
+			taskIsInvoked := false
+			testee := graph.Task(func(
+				ctx context.Context,
+				client krst.KnitClient,
+				graph *knitgraph.DirectedGraph,
+				planId string,
+				dir graph.Direction,
+				maxDepth args.Depth,
+			) (*knitgraph.DirectedGraph, error) {
+				taskIsInvoked = true
+
+				if graph == nil {
+					t.Errorf("graph is nil")
+				}
+
+				if planId != then.PlanId {
+					t.Errorf("wrong planId: %s", planId)
+				}
+
+				if dir != then.Dir {
+					t.Errorf("wrong direction: %v", dir)
+				}
+
+				if !maxDepth.Equal(then.MaxDepth) {
+					t.Errorf("wrong maxDepth: %v", maxDepth)
+				}
+
+				return graph, when.Err
+			})
+
+			got := testee(
+				ctx,
+				logger,
+				*env.New(),
+				client,
+				fakeCommandline,
+				[]interface{}{},
+			)
+
+			if then.taskIsInvoked != taskIsInvoked {
+				t.Errorf("wrong taskIsInvoked: %v", taskIsInvoked)
+			}
+
+			if !errors.Is(got, then.Err) {
+				t.Errorf("wrong status: (actual, expected) != (%v, %v)", got, then.Err)
+			}
+		}
+	}
+
+	t.Run("-u and -d is not passed, both are activated", theory(
+		When{
+			Flag: graph.Flag{
+				Numbers:    pointer.Ref(args.NewDepth(42)),
+				Upstream:   nil,
+				Downstream: nil,
+			},
+			Args: map[string][]string{
+				graph.ARG_PLANID: {"test-Id"},
+			},
+			Err: nil,
+		},
+		Then{
+			PlanId: "test-Id",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: true,
+			},
+			MaxDepth:      args.NewDepth(42),
+			taskIsInvoked: true,
+			Err:           nil,
+		},
+	))
+
+	t.Run("-u is passed, -d is not passed, only -u is activated", theory(
+		When{
+			Flag: graph.Flag{
+				Numbers:    pointer.Ref(args.NewDepth(42)),
+				Upstream:   pointer.Ref(true),
+				Downstream: nil,
+			},
+			Args: map[string][]string{
+				graph.ARG_PLANID: {"test-Id"},
+			},
+			Err: nil,
+		},
+		Then{
+			PlanId: "test-Id",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: false,
+			},
+			MaxDepth:      args.NewDepth(42),
+			taskIsInvoked: true,
+			Err:           nil,
+		},
+	))
+
+	t.Run("-d is passed, -u is not passed, only -d is activated", theory(
+		When{
+			Flag: graph.Flag{
+				Numbers:    pointer.Ref(args.NewDepth(42)),
+				Upstream:   nil,
+				Downstream: pointer.Ref(true),
+			},
+			Args: map[string][]string{
+				graph.ARG_PLANID: {"test-Id"},
+			},
+			Err: nil,
+		},
+		Then{
+			PlanId: "test-Id",
+			Dir: graph.Direction{
+				Upstream:   false,
+				Downstream: true,
+			},
+			MaxDepth:      args.NewDepth(42),
+			taskIsInvoked: true,
+			Err:           nil,
+		},
+	))
+
+	t.Run("-u and -d is passed, both are activated", theory(
+		When{
+			Flag: graph.Flag{
+				Numbers:    pointer.Ref(args.NewDepth(42)),
+				Upstream:   pointer.Ref(true),
+				Downstream: pointer.Ref(true),
+			},
+			Args: map[string][]string{
+				graph.ARG_PLANID: {"test-Id"},
+			},
+			Err: nil,
+		},
+		Then{
+			PlanId: "test-Id",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: true,
+			},
+			MaxDepth:      args.NewDepth(42),
+			taskIsInvoked: true,
+			Err:           nil,
+		},
+	))
+
+	t.Run("when --number is zero, it returns an ErrUsage", theory(
+		When{
+			Flag: graph.Flag{
+				Numbers:    pointer.Ref(args.NewDepth(0)),
+				Upstream:   nil,
+				Downstream: nil,
+			},
+			Args: map[string][]string{
+				graph.ARG_PLANID: {"test-Id"},
+			},
+			Err: nil,
+		},
+		Then{
+			taskIsInvoked: false,
+			Err:           flarc.ErrUsage,
+		},
+	))
+
+	fakeError := errors.New("fake error")
+	t.Run("when, error is caused, it returns the error", theory(
+		When{
+			Flag: graph.Flag{
+				Numbers:    pointer.Ref(args.NewDepth(42)),
+				Upstream:   nil,
+				Downstream: nil,
+			},
+			Args: map[string][]string{
+				graph.ARG_PLANID: {"test-Id"},
+			},
+			Err: fakeError,
+		},
+		Then{
+			PlanId: "test-Id",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: true,
+			},
+			MaxDepth:      args.NewDepth(42),
+			taskIsInvoked: true,
+			Err:           fakeError,
+		},
+	))
+
+}
+
+func TestMakeGraph(t *testing.T) {
+
+	type When struct {
+		StartingPlanId string
+		Dir            graph.Direction
+		MaxDepth       args.Depth
+
+		Plans    map[string]plans.Detail
+		ErrPlans map[string]error
+	}
+
+	type Then struct {
+		FoundPlanIds []string
+		Err          error
+	}
+
+	theory := func(when When, then Then) func(*testing.T) {
+		return func(t *testing.T) {
+			ctx := context.Background()
+
+			client := krstmock.New(t)
+			client.Impl.GetPlans = func(
+				ctx context.Context,
+				planId string,
+			) (plans.Detail, error) {
+				if err, ok := when.ErrPlans[planId]; ok {
+					return plans.Detail{}, err
+				}
+				if plan, ok := when.Plans[planId]; ok {
+					return plan, nil
+				}
+
+				return plans.Detail{}, errors.New("not found")
+			}
+
+			g := knitgraph.NewDirectedGraph()
+			got, err := graph.MakeGraph(
+				ctx, client, g, when.StartingPlanId, when.Dir, when.MaxDepth,
+			)
+
+			if !errors.Is(err, then.Err) {
+				t.Errorf("wrong status: (actual, expected) != (%v, %v)", err, then.Err)
+			}
+
+			if got != nil {
+				foundPlanIds := slices.Map(
+					got.PlanNodes.Values(),
+					func(n knitgraph.PlanNode) string { return n.PlanId },
+				)
+
+				if !cmp.SliceEq(foundPlanIds, then.FoundPlanIds) {
+					t.Errorf("wrong foundPlanIds: %v", foundPlanIds)
+				}
+			}
+		}
+	}
+
+	//
+	// (upstream side)
+	//
+	//                                                      (no upstream here) .-[/in/1]-
+	//                                                                                   \
+	// p_a --[/out/1]-.-[/in/1]--> p_b --[/out/1]-.-[/in/1]--> p_c --[/out/1]-.-[/in/2] --> p_d --[(log)]-.-[/in/1]--> p_start
+	//                \                                                                                   /         |
+	//                 -----------------------------------------------------.-[/in/1]--> p_e --[/out/1]-.-          |
+	//                                                                      |                                       /
+	//                                                                     /           (no upstream here) .-[/in/2]-
+	//                     (no upstream here) .--[/in/1]--> p_f --[/out/1]-
+	//
+	//
+	// (downstream side)
+	//
+	// p_start --[/out/1]-.-[/in/1]--> p_1 --[/out/1]-.-[/in/1]--> p_2 --[/out/1]-.-[/in/1]--> p_3 --[/out/1]-.-[/in/1]--> p_4
+	//         |           \                                                                                 /
+	//         |            -[/in/1]--> p_5 --[(log)]--------------------------------------------------------
+	//         |                            |        \
+	//         |                            |         -. -[/in/1]--> p_6
+	//         |                             \
+	//         |                               -[/out/1]-.-[/in/1]--> p_7
+	//         |\
+	//         | -[/out/2]-.(no downstream here)
+	//          \
+	//           -[(log)]-.-[/in/1]--> p_8 --[(log)]-. (no downstream here)
+	//
+	// (explanatory notes)
+	//
+	// p_1 --[output path of p_1]-.-[input path of p_2]--> p_2
+	// ^^^
+	//  |
+	// planId
+	//
+	fakePlans := map[string]plans.Detail{
+		"p_start": {
+			Summary: plans.Summary{
+				PlanId: "p_start",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan: plans.Summary{PlanId: "p_d"},
+							Log:  &plans.LogPoint{},
+						},
+						{
+							Plan:       plans.Summary{PlanId: "p_e"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/2"},
+					Upstreams:  []plans.Upstream{},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_1"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+						{
+							Plan:       plans.Summary{PlanId: "p_5"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+				{
+					Mountpoint:  plans.Mountpoint{Path: "/out/2"},
+					Downstreams: []plans.Downstream{},
+				},
+			},
+			Log: &plans.Log{
+				Downstreams: []plans.Downstream{
+					{
+						Plan:       plans.Summary{PlanId: "p_8"},
+						Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					},
+				},
+			},
+		},
+		"p_a": {
+			Summary: plans.Summary{
+				PlanId: "p_a",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams:  []plans.Upstream{},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_b"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+						{
+							Plan:       plans.Summary{PlanId: "p_e"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		},
+		"p_b": {
+			Summary: plans.Summary{
+				PlanId: "p_b",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_a"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_c"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		},
+		"p_c": {
+			Summary: plans.Summary{
+				PlanId: "p_c",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_b"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_d"},
+							Mountpoint: plans.Mountpoint{Path: "/in/2"},
+						},
+					},
+				},
+			},
+		},
+		"p_d": {
+			Summary: plans.Summary{
+				PlanId: "p_d",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams:  []plans.Upstream{},
+				},
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/2"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_c"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{},
+			Log: &plans.Log{
+				Downstreams: []plans.Downstream{
+					{
+						Plan:       plans.Summary{PlanId: "p_start"},
+						Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					},
+				},
+			},
+		},
+		"p_e": {
+			Summary: plans.Summary{
+				PlanId: "p_e",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_a"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+						{
+							Plan:       plans.Summary{PlanId: "p_f"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_start"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		},
+		"p_f": {
+			Summary: plans.Summary{
+				PlanId: "p_f",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams:  []plans.Upstream{},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_e"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		},
+		"p_1": {
+			Summary: plans.Summary{
+				PlanId: "p_1",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_start"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_2"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		},
+		"p_2": {
+			Summary: plans.Summary{
+				PlanId: "p_2",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_1"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_3"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		},
+		"p_3": {
+			Summary: plans.Summary{
+				PlanId: "p_3",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_2"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_4"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+		},
+		"p_4": {
+			Summary: plans.Summary{
+				PlanId: "p_4",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_3"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+						{
+							Plan: plans.Summary{PlanId: "p_5"},
+							Log:  &plans.LogPoint{},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{},
+		},
+		"p_5": {
+			Summary: plans.Summary{
+				PlanId: "p_5",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_start"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/out/1"},
+					Downstreams: []plans.Downstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_7"},
+							Mountpoint: plans.Mountpoint{Path: "/in/1"},
+						},
+					},
+				},
+			},
+			Log: &plans.Log{
+				Downstreams: []plans.Downstream{
+					{
+						Plan:       plans.Summary{PlanId: "p_4"},
+						Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					},
+					{
+						Plan:       plans.Summary{PlanId: "p_6"},
+						Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					},
+				},
+			},
+		},
+		"p_6": {
+			Summary: plans.Summary{
+				PlanId: "p_6",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_5"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{},
+		},
+		"p_7": {
+			Summary: plans.Summary{
+				PlanId: "p_7",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan:       plans.Summary{PlanId: "p_5"},
+							Mountpoint: &plans.Mountpoint{Path: "/out/1"},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{},
+		},
+		"p_8": {
+			Summary: plans.Summary{
+				PlanId: "p_8",
+				Image: &plans.Image{
+					Repository: "test-Image", Tag: "test-Version",
+				},
+			},
+			Inputs: []plans.Input{
+				{
+					Mountpoint: plans.Mountpoint{Path: "/in/1"},
+					Upstreams: []plans.Upstream{
+						{
+							Plan: plans.Summary{PlanId: "p_start"},
+							Log:  &plans.LogPoint{},
+						},
+					},
+				},
+			},
+			Outputs: []plans.Output{},
+			Log: &plans.Log{
+				Downstreams: []plans.Downstream{},
+			},
+		},
+	}
+
+	t.Run("traverse graph to upstream only upto depth 2", theory(
+		When{
+			StartingPlanId: "p_start",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: false,
+			},
+			MaxDepth: args.NewDepth(2),
+
+			Plans: fakePlans,
+		},
+		Then{
+			FoundPlanIds: []string{
+				"p_start",
+				"p_d",
+				"p_e",
+				"p_c",
+				"p_a",
+				"p_f",
+			},
+			Err: nil,
+		},
+	))
+
+	t.Run("traverse graph to downstream only upto depth 2", theory(
+		When{
+			StartingPlanId: "p_start",
+			Dir: graph.Direction{
+				Upstream:   false,
+				Downstream: true,
+			},
+			MaxDepth: args.NewDepth(2),
+
+			Plans: fakePlans,
+		},
+		Then{
+			FoundPlanIds: []string{
+				"p_start",
+				"p_1",
+				"p_5",
+				"p_8",
+				"p_2",
+				"p_7",
+				"p_4",
+				"p_6",
+			},
+			Err: nil,
+		},
+	))
+
+	t.Run("traverse graph to up- and downstream upto depth 2", theory(
+		When{
+			StartingPlanId: "p_start",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: true,
+			},
+			MaxDepth: args.NewDepth(2),
+
+			Plans: fakePlans,
+		},
+		Then{
+			FoundPlanIds: []string{
+				"p_start",
+				// upstream
+				"p_d",
+				"p_e",
+				"p_c",
+				"p_a",
+				"p_f",
+				// downstream
+				"p_1",
+				"p_5",
+				"p_8",
+				"p_2",
+				"p_7",
+				"p_4",
+				"p_6",
+			},
+			Err: nil,
+		},
+	))
+
+	t.Run("traverse graph to up- and downstream unlimitedly", theory(
+		When{
+			StartingPlanId: "p_start",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: true,
+			},
+			MaxDepth: args.NewInfinityDepth(),
+
+			Plans: fakePlans,
+		},
+		Then{
+			FoundPlanIds: []string{
+				"p_start",
+				// upstream
+				"p_d",
+				"p_e",
+				"p_c",
+				"p_a",
+				"p_f",
+				"p_b",
+				// downstream
+				"p_1",
+				"p_5",
+				"p_8",
+				"p_2",
+				"p_7",
+				"p_4",
+				"p_6",
+				"p_3",
+			},
+			Err: nil,
+		},
+	))
+
+	fakeErr := errors.New("fake error")
+	t.Run("upstream: when error is caused in client, it returns the error", theory(
+		When{
+			StartingPlanId: "p_start",
+			Dir: graph.Direction{
+				Upstream:   true,
+				Downstream: false,
+			},
+			MaxDepth: args.NewDepth(2),
+
+			Plans:    fakePlans,
+			ErrPlans: map[string]error{"p_a": fakeErr},
+		},
+		Then{
+			FoundPlanIds: nil,
+			Err:          fakeErr,
+		},
+	))
+
+	t.Run("downstream: when error is caused in client, it returns the error", theory(
+		When{
+			StartingPlanId: "p_start",
+			Dir: graph.Direction{
+				Upstream:   false,
+				Downstream: true,
+			},
+			MaxDepth: args.NewDepth(2),
+
+			Plans:    fakePlans,
+			ErrPlans: map[string]error{"p_1": fakeErr},
+		},
+		Then{
+			FoundPlanIds: nil,
+			Err:          fakeErr,
+		},
+	))
+
+}

--- a/pkg/utils/args/depth.go
+++ b/pkg/utils/args/depth.go
@@ -1,0 +1,69 @@
+package args
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Depth is a type that represents the depth of a search.
+type Depth struct {
+	n        uint
+	infinity bool
+}
+
+func (d Depth) String() string {
+	if d.infinity {
+		return "all"
+	}
+	return fmt.Sprintf("%v", d.n)
+}
+
+// Value returns the value of the depth.
+//
+// Regardless of whether the depth is infinity or not, this function will return the value of the depth.
+func (d Depth) Value() uint {
+	return d.n
+}
+
+// IsInfinity returns whether the depth is infinity.
+func (d Depth) IsInfinity() bool {
+	return d.infinity
+}
+
+// NewDepth creates a new (finite) Depth with the given value.
+func NewDepth(value uint) Depth {
+	return Depth{n: value, infinity: false}
+}
+
+// NewInfinityDepth creates a new infinity Depth.
+func NewInfinityDepth() Depth {
+	return Depth{n: 0, infinity: true}
+}
+
+func (d Depth) Equal(other Depth) bool {
+	if d.infinity != other.infinity {
+		return false
+	}
+	if d.infinity {
+		return true
+	}
+
+	return d.n == other.n
+}
+
+// Set sets the value of the depth.
+//
+// Compliant with the flag.Value interface.
+func (d *Depth) Set(s string) error {
+	if s == "all" {
+		d.infinity = true
+		return nil
+	}
+
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf(`the value should be non-negative integer or "all": %v`, s)
+	}
+	d.n = (uint)(v)
+	return nil
+}

--- a/pkg/utils/args/depth.go
+++ b/pkg/utils/args/depth.go
@@ -30,6 +30,24 @@ func (d Depth) IsInfinity() bool {
 	return d.infinity
 }
 
+// IsZero returns whether the depth is zero.
+func (d Depth) IsZero() bool {
+	return d.n == 0 && !d.infinity
+}
+
+func (d Depth) Add(n int) Depth {
+	if d.infinity {
+		return NewInfinityDepth()
+	}
+	if n < 0 {
+		if d.n < uint(-n) {
+			return NewDepth(0)
+		}
+		return NewDepth(d.n - uint(-n))
+	}
+	return NewDepth(d.n + uint(n))
+}
+
 // NewDepth creates a new (finite) Depth with the given value.
 func NewDepth(value uint) Depth {
 	return Depth{n: value, infinity: false}

--- a/pkg/utils/args/depth_test.go
+++ b/pkg/utils/args/depth_test.go
@@ -42,4 +42,44 @@ func TestDepth(t *testing.T) {
 			t.Errorf("Expected error, got nil")
 		}
 	})
+
+	t.Run("Add positive value", func(t *testing.T) {
+		depth := args.NewDepth(10)
+		depth = depth.Add(5)
+		if depth.Value() != 15 {
+			t.Errorf("Expected 15, got %v", depth.Value())
+		}
+	})
+
+	t.Run("Add negative value", func(t *testing.T) {
+		depth := args.NewDepth(10)
+		depth = depth.Add(-5)
+		if depth.Value() != 5 {
+			t.Errorf("Expected 5, got %v", depth.Value())
+		}
+	})
+
+	t.Run("Add negative value to zero", func(t *testing.T) {
+		depth := args.NewDepth(3)
+		depth = depth.Add(-5)
+		if depth.Value() != 0 {
+			t.Errorf("Expected 0, got %v", depth.Value())
+		}
+	})
+
+	t.Run("Add positive value to infinity", func(t *testing.T) {
+		depth := args.NewInfinityDepth()
+		depth = depth.Add(5)
+		if !depth.IsInfinity() {
+			t.Errorf("Expected true, got false")
+		}
+	})
+
+	t.Run("Add negative value to infinity", func(t *testing.T) {
+		depth := args.NewInfinityDepth()
+		depth = depth.Add(-5)
+		if !depth.IsInfinity() {
+			t.Errorf("Expected true, got false")
+		}
+	})
 }

--- a/pkg/utils/args/depth_test.go
+++ b/pkg/utils/args/depth_test.go
@@ -1,0 +1,45 @@
+package args_test
+
+import (
+	"testing"
+
+	"github.com/opst/knitfab/pkg/utils/args"
+)
+
+func TestDepth(t *testing.T) {
+	t.Run("Set finite value", func(t *testing.T) {
+		depth := new(args.Depth)
+		err := depth.Set("10")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if depth.Value() != 10 {
+			t.Errorf("Expected 10, got %v", depth.Value())
+		}
+		if depth.IsInfinity() {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("Set infinity value", func(t *testing.T) {
+		depth := new(args.Depth)
+		err := depth.Set("all")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if depth.Value() != 0 {
+			t.Errorf("Expected 0, got %v", depth.Value())
+		}
+		if !depth.IsInfinity() {
+			t.Errorf("Expected true, got false")
+		}
+	})
+
+	t.Run("Set invalid value", func(t *testing.T) {
+		depth := new(args.Depth)
+		err := depth.Set("invalid")
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+	})
+}

--- a/pkg/utils/maps/maps.go
+++ b/pkg/utils/maps/maps.go
@@ -16,3 +16,32 @@ func RefOf[K comparable, V any](m map[K]V) map[K]*V {
 	}
 	return ret
 }
+
+// Map is a generic interface for a map-like data structure.
+type Map[K comparable, V any] interface {
+	// Set sets the value for the key.
+	//
+	// If the key is already present, the value is overwritten.
+	Set(k K, v V)
+
+	// Get returns the value for the key and a boolean indicating if the key was present.
+	Get(k K) (V, bool)
+
+	// Keys returns the keys in the map.
+	Keys() []K
+
+	// Values returns the values in the map.
+	Values() []V
+
+	// Keys returns the keys in the map.
+	Delete(k K)
+
+	// Len returns the number of keys in the map.
+	Len() int
+
+	// Iter returns a function that iterates over the map.
+	Iter() func(yield func(k K, v V) bool)
+
+	// ToMap returns a map[K]V.
+	ToMap() map[K]V
+}

--- a/pkg/utils/maps/ordered.go
+++ b/pkg/utils/maps/ordered.go
@@ -1,0 +1,82 @@
+package maps
+
+import "github.com/opst/knitfab/pkg/utils/tuple"
+
+type orderedMap[K comparable, V any] struct {
+	keys []K
+	m    map[K]V
+}
+
+// NewOrderedMap creates a new ordered map with the given initial key-value pairs.
+//
+// The keys will be ordered in the order they were added.
+func NewOrderedMap[K comparable, V any](initial ...tuple.Pair[K, V]) Map[K, V] {
+	m := &orderedMap[K, V]{
+		keys: []K{},
+		m:    map[K]V{},
+	}
+
+	for _, pair := range initial {
+		m.Set(pair.First, pair.Second)
+	}
+
+	return m
+}
+
+func (m *orderedMap[K, V]) Set(k K, v V) {
+	if _, ok := m.m[k]; !ok {
+		m.keys = append(m.keys, k)
+	}
+	m.m[k] = v
+}
+
+func (m *orderedMap[K, V]) Get(k K) (V, bool) {
+	v, ok := m.m[k]
+	return v, ok
+}
+
+func (m *orderedMap[K, V]) Keys() []K {
+	return m.keys
+}
+
+func (m *orderedMap[K, V]) Values() []V {
+	values := make([]V, len(m.keys))
+	for i, k := range m.keys {
+		values[i] = m.m[k]
+	}
+	return values
+}
+
+func (m *orderedMap[K, V]) Delete(k K) {
+	delete(m.m, k)
+	for i, key := range m.keys {
+		if key == k {
+			m.keys = append(m.keys[:i], m.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+func (m *orderedMap[K, V]) Len() int {
+	return len(m.keys)
+}
+
+func (m *orderedMap[K, V]) Iter() func(yield func(k K, v V) bool) {
+	return func(yield func(k K, v V) bool) {
+		for _, k := range m.keys {
+			v := m.m[k]
+			if !yield(k, v) {
+				break
+			}
+		}
+	}
+}
+
+func (m *orderedMap[K, V]) ToMap() map[K]V {
+	// Return a copy of the map to prevent modification of the internal map.
+	ret := map[K]V{}
+	for k, v := range m.m {
+		ret[k] = v
+	}
+	return ret
+}

--- a/pkg/utils/maps/ordered_test.go
+++ b/pkg/utils/maps/ordered_test.go
@@ -1,0 +1,279 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/opst/knitfab/pkg/utils/cmp"
+	"github.com/opst/knitfab/pkg/utils/tuple"
+)
+
+func TestOrderedMap(t *testing.T) {
+	testee := NewOrderedMap(
+		tuple.PairOf(1, "one"),
+		tuple.PairOf(-2, "two"),
+	)
+	testee.Set(3, "three")
+
+	{
+		v, ok := testee.Get(1)
+		if !ok {
+			t.Errorf("Expected key 1 to be present")
+		}
+		if v != "one" {
+			t.Errorf("Expected value to be one, got %s", v)
+		}
+	}
+	{
+		v, ok := testee.Get(-2)
+		if !ok {
+			t.Errorf("Expected key 2 to be present")
+		}
+		if v != "two" {
+			t.Errorf("Expected value to be two, got %s", v)
+		}
+	}
+	{
+		v, ok := testee.Get(3)
+		if !ok {
+			t.Errorf("Expected key 3 to be present")
+		}
+		if v != "three" {
+			t.Errorf("Expected value to be three, got %s", v)
+		}
+	}
+	{
+		_, ok := testee.Get(4)
+		if ok {
+			t.Errorf("Expected key 4 to be absent")
+		}
+	}
+
+	{
+		got := testee.Len()
+		if want := 3; got != want {
+			t.Errorf("Expected length to be %d, got %d", want, got)
+		}
+	}
+
+	{
+		keys := testee.Keys()
+		if want := []int{1, -2, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+	}
+	{
+		values := testee.Values()
+		if want := []string{"one", "two", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+	{
+		keys := []int{}
+		values := []string{}
+
+		for k, v := range testee.Iter() {
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+
+		if want := []int{1, -2, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+		if want := []string{"one", "two", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+
+	testee.Delete(-2)
+
+	{
+		got, ok := testee.Get(1)
+		if !ok {
+			t.Errorf("Expected key 1 to be present")
+		}
+		if got != "one" {
+			t.Errorf("Expected value to be one, got %s", got)
+		}
+	}
+	{
+		_, ok := testee.Get(-2)
+		if ok {
+			t.Errorf("Expected key 2 to be absent")
+		}
+	}
+	{
+		got, ok := testee.Get(3)
+		if !ok {
+			t.Errorf("Expected key 3 to be present")
+		}
+		if got != "three" {
+			t.Errorf("Expected value to be three, got %s", got)
+		}
+	}
+	{
+		_, ok := testee.Get(4)
+		if ok {
+			t.Errorf("Expected key 4 to be absent")
+		}
+	}
+	{
+		got := testee.Len()
+		if want := 2; got != want {
+			t.Errorf("Expected length to be %d, got %d", want, got)
+		}
+	}
+	{
+		keys := testee.Keys()
+		if want := []int{1, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+	}
+
+	{
+		values := testee.Values()
+		if want := []string{"one", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+	{
+		keys := []int{}
+		values := []string{}
+
+		for k, v := range testee.Iter() {
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+
+		if want := []int{1, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+		if want := []string{"one", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+
+	testee.Delete(2)  // Delete non-existent key
+	testee.Delete(-1) // Delete non-existent key
+
+	{
+		got, ok := testee.Get(1)
+		if !ok {
+			t.Errorf("Expected key 1 to be present")
+		}
+		if got != "one" {
+			t.Errorf("Expected value to be one, got %s", got)
+		}
+	}
+	{
+		_, ok := testee.Get(-2)
+		if ok {
+			t.Errorf("Expected key 2 to be absent")
+		}
+	}
+	{
+		got, ok := testee.Get(3)
+		if !ok {
+			t.Errorf("Expected key 3 to be present")
+		}
+		if got != "three" {
+			t.Errorf("Expected value to be three, got %s", got)
+		}
+	}
+	{
+		_, ok := testee.Get(4)
+		if ok {
+			t.Errorf("Expected key 4 to be absent")
+		}
+	}
+	{
+		got := testee.Len()
+		if want := 2; got != want {
+			t.Errorf("Expected length to be %d, got %d", want, got)
+		}
+	}
+	{
+		keys := testee.Keys()
+		if want := []int{1, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+	}
+
+	{
+		values := testee.Values()
+		if want := []string{"one", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+	{
+		keys := []int{}
+		values := []string{}
+
+		for k, v := range testee.Iter() {
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+
+		if want := []int{1, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+		if want := []string{"one", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+
+	testee.Set(1, "ONE") // update value
+
+	{
+		got, ok := testee.Get(1)
+		if !ok {
+			t.Errorf("Expected key 1 to be present")
+		}
+		if got != "ONE" {
+			t.Errorf("Expected value to be ONE, got %s", got)
+		}
+	}
+	{
+		got, ok := testee.Get(3)
+		if !ok {
+			t.Errorf("Expected key 3 to be present")
+		}
+		if got != "three" {
+			t.Errorf("Expected value to be three, got %s", got)
+		}
+	}
+	{
+		got := testee.Len()
+		if want := 2; got != want {
+			t.Errorf("Expected length to be %d, got %d", want, got)
+		}
+	}
+	{
+		keys := testee.Keys()
+		if want := []int{1, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+	}
+	{
+		values := testee.Values()
+		if want := []string{"ONE", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+	{
+		keys := []int{}
+		values := []string{}
+
+		for k, v := range testee.Iter() {
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+
+		if want := []int{1, 3}; !cmp.SliceEq(keys, want) {
+			t.Errorf("Expected keys to be %v, got %v", want, keys)
+		}
+		if want := []string{"ONE", "three"}; !cmp.SliceEq(values, want) {
+			t.Errorf("Expected values to be %v, got %v", want, values)
+		}
+	}
+
+}


### PR DESCRIPTION
## About This PR

Introduce new subcommand `knit plan graph`, explains overview of Plans.

To do that, type `DirecterdGraph` is extracted from `knit data lineage` (`cmd/knit/subcommand/data/lineage`) to `cmd/knit/knitgraph`, extended to handle Plans, and simplified to register edges.

## Related Issues

- closes #24 

