### PR TITLE
fix parsing algorithms for container image name

### DIFF
--- a/cmd/knit/rest/client.go
+++ b/cmd/knit/rest/client.go
@@ -147,7 +147,8 @@ type KnitClient interface {
 	//                  false if plan to be found is deactivated,
 	//                  indeterminate if plan to be found is either activated or deactivated.
 	//
-	// - kdb.ImageIdentifier: image which plan to be found has
+	// - kdb.ImageIdentifier: image which plan to be found has.
+	// Pass nil when ImageIdentifier is not specified.
 	//
 	// - []apitag.Tag: tags which plan to be found has as input
 	//
@@ -159,7 +160,7 @@ type KnitClient interface {
 	//
 	// - error
 	FindPlan(
-		ctx context.Context, active logic.Ternary, imageVer domain.ImageIdentifier,
+		ctx context.Context, active logic.Ternary, imageVer *domain.ImageIdentifier,
 		inTags []tags.Tag, outTags []tags.Tag,
 	) ([]plans.Detail, error)
 

--- a/cmd/knit/rest/mock/mock.go
+++ b/cmd/knit/rest/mock/mock.go
@@ -26,7 +26,7 @@ type PutTagsForDataArgs struct {
 
 type FindPlanArgs struct {
 	Active   logic.Ternary
-	ImageVer domain.ImageIdentifier
+	ImageVer *domain.ImageIdentifier
 	InTags   []apitags.Tag
 	OutTags  []apitags.Tag
 }
@@ -112,7 +112,7 @@ type mockKnitClient struct {
 
 		GetPlans func(ctx context.Context, planId string) (plans.Detail, error)
 		FindPlan func(
-			ctx context.Context, active logic.Ternary, imageVer domain.ImageIdentifier,
+			ctx context.Context, active logic.Ternary, imageVer *domain.ImageIdentifier,
 			inTags []apitags.Tag, outTags []apitags.Tag,
 		) ([]plans.Detail, error)
 		PutPlanForActivate  func(ctx context.Context, planId string, isActive bool) (plans.Detail, error)
@@ -235,7 +235,7 @@ func (m *mockKnitClient) GetPlans(ctx context.Context, planId string) (plans.Det
 func (m *mockKnitClient) FindPlan(
 	ctx context.Context,
 	active logic.Ternary,
-	imageVer domain.ImageIdentifier,
+	imageVer *domain.ImageIdentifier,
 	inTags []apitags.Tag,
 	outTags []apitags.Tag,
 ) ([]plans.Detail, error) {

--- a/cmd/knit/rest/plan.go
+++ b/cmd/knit/rest/plan.go
@@ -90,7 +90,7 @@ func (c *client) RegisterPlan(ctx context.Context, spec plans.PlanSpec) (plans.D
 func (c *client) FindPlan(
 	ctx context.Context,
 	active logic.Ternary,
-	imageVer domain.ImageIdentifier,
+	imageVer *domain.ImageIdentifier,
 	inTags []tags.Tag,
 	outTags []tags.Tag,
 ) ([]plans.Detail, error) {
@@ -110,10 +110,8 @@ func (c *client) FindPlan(
 		// add nothing
 	}
 
-	if imageVer.Image != "" {
-		q.Add("image", fmt.Sprintf("%s:%s", imageVer.Image, imageVer.Version))
-	} else if imageVer.Version != "" {
-		return nil, err
+	if imageVer != nil {
+		q.Add("image", imageVer.String())
 	}
 
 	inTagCount := len(inTags)

--- a/cmd/knit/rest/plan_test.go
+++ b/cmd/knit/rest/plan_test.go
@@ -641,7 +641,7 @@ func TestFindPlan(t *testing.T) {
 
 		type when struct {
 			active   logic.Ternary
-			imageVer domain.ImageIdentifier
+			imageVer *domain.ImageIdentifier
 			inTags   []tags.Tag
 			outTags  []tags.Tag
 		}
@@ -661,7 +661,7 @@ func TestFindPlan(t *testing.T) {
 			"when query with active:Indeterminate nothing else, server receives empty query string": {
 				when: when{
 					active:   logic.Indeterminate,
-					imageVer: domain.ImageIdentifier{},
+					imageVer: nil,
 					inTags:   []tags.Tag{},
 					outTags:  []tags.Tag{},
 				},
@@ -675,7 +675,7 @@ func TestFindPlan(t *testing.T) {
 			"when query with active:true, server receives this": {
 				when: when{
 					active:   logic.True,
-					imageVer: domain.ImageIdentifier{},
+					imageVer: nil,
 					inTags:   []tags.Tag{},
 					outTags:  []tags.Tag{},
 				},
@@ -689,7 +689,7 @@ func TestFindPlan(t *testing.T) {
 			"when query with active:false, server receives this": {
 				when: when{
 					active:   logic.False,
-					imageVer: domain.ImageIdentifier{},
+					imageVer: nil,
 					inTags:   []tags.Tag{},
 					outTags:  []tags.Tag{},
 				},
@@ -703,7 +703,7 @@ func TestFindPlan(t *testing.T) {
 			"when query with imageVer, server receives this": {
 				when: when{
 					active: logic.Indeterminate,
-					imageVer: domain.ImageIdentifier{
+					imageVer: &domain.ImageIdentifier{
 						Image:   "image-test",
 						Version: "v0.0.1",
 					},
@@ -720,7 +720,7 @@ func TestFindPlan(t *testing.T) {
 			"when query with tags, server receives them": {
 				when: when{
 					active:   logic.Indeterminate,
-					imageVer: domain.ImageIdentifier{},
+					imageVer: nil,
 					inTags: []tags.Tag{
 						{Key: "key-a", Value: "value/a"},
 						{Key: "type", Value: "unknown?"},
@@ -828,7 +828,7 @@ func TestFindPlan(t *testing.T) {
 			// prepare for the tests
 			profile := kprof.KnitProfile{ApiRoot: ts.URL}
 			queryActive := logic.Indeterminate
-			queryImagever := domain.ImageIdentifier{
+			queryImagever := &domain.ImageIdentifier{
 				Image: "test-image", Version: "test-version",
 			}
 			queryInTags := []tags.Tag{
@@ -882,7 +882,7 @@ func TestFindPlan(t *testing.T) {
 					t.Fatal(err.Error())
 				}
 				queryActive := logic.Indeterminate
-				queryImagever := domain.ImageIdentifier{
+				queryImagever := &domain.ImageIdentifier{
 					Image: "test-image", Version: "test-version",
 				}
 				queryInTags := []tags.Tag{

--- a/cmd/knit/subcommands/plan/find/command.go
+++ b/cmd/knit/subcommands/plan/find/command.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/opst/knitfab-api-types/plans"
 	"github.com/opst/knitfab-api-types/tags"
@@ -31,7 +30,7 @@ type Option struct {
 		log *log.Logger,
 		client krst.KnitClient,
 		active logic.Ternary,
-		imageVer domain.ImageIdentifier,
+		imageVer *domain.ImageIdentifier,
 		inTags []tags.Tag,
 		outTags []tags.Tag,
 	) ([]plans.Detail, error)
@@ -43,7 +42,7 @@ func WithFind(
 		log *log.Logger,
 		client krst.KnitClient,
 		active logic.Ternary,
-		imageVer domain.ImageIdentifier,
+		imageVer *domain.ImageIdentifier,
 		inTags []tags.Tag,
 		outTags []tags.Tag,
 	) ([]plans.Detail, error),
@@ -113,7 +112,7 @@ func Task(
 		log *log.Logger,
 		client krst.KnitClient,
 		active logic.Ternary,
-		imageVer domain.ImageIdentifier,
+		imageVer *domain.ImageIdentifier,
 		inTags []tags.Tag,
 		outTags []tags.Tag,
 	) ([]plans.Detail, error),
@@ -143,13 +142,12 @@ func Task(
 			)
 		}
 
-		image, version, ok := strings.Cut(flags.Image, ":")
-		if ok && image == "" {
-			return fmt.Errorf("%w: --image: only tag is passed", flarc.ErrUsage)
-		}
-		imageVer := domain.ImageIdentifier{
-			Image:   image,
-			Version: version,
+		var imageVer *domain.ImageIdentifier
+		if flags.Image != "" {
+			imageVer = new(domain.ImageIdentifier)
+			if err := imageVer.Parse(flags.Image); err != nil {
+				return fmt.Errorf("%w: --image: %s", flarc.ErrUsage, err)
+			}
 		}
 
 		inTags := []tags.Tag{}
@@ -182,7 +180,7 @@ func RunFindPlan(
 	log *log.Logger,
 	client krst.KnitClient,
 	active logic.Ternary,
-	imageVer domain.ImageIdentifier,
+	imageVer *domain.ImageIdentifier,
 	inTags []tags.Tag,
 	outTags []tags.Tag,
 ) ([]plans.Detail, error) {

--- a/cmd/knit/subcommands/plan/find/command_test.go
+++ b/cmd/knit/subcommands/plan/find/command_test.go
@@ -37,7 +37,7 @@ func TestFindCommand(t *testing.T) {
 	type Then struct {
 		err      error
 		active   logic.Ternary
-		imageVer domain.ImageIdentifier
+		imageVer *domain.ImageIdentifier
 	}
 
 	presentationItems := []plans.Detail{
@@ -121,7 +121,7 @@ func TestFindCommand(t *testing.T) {
 			task := func(
 				_ context.Context, _ *log.Logger, _ krst.KnitClient,
 				active logic.Ternary,
-				image domain.ImageIdentifier,
+				image *domain.ImageIdentifier,
 				inTags []tags.Tag,
 				outTags []tags.Tag,
 			) ([]plans.Detail, error) {
@@ -132,7 +132,7 @@ func TestFindCommand(t *testing.T) {
 					)
 				}
 
-				if image != then.imageVer {
+				if !image.Equal(then.imageVer) {
 					t.Errorf(
 						"wrong image: (actual, expected) != (%+v, %+v)",
 						image, then.imageVer,
@@ -280,7 +280,7 @@ func TestFindCommand(t *testing.T) {
 		},
 		Then{
 			active: logic.Indeterminate,
-			imageVer: domain.ImageIdentifier{
+			imageVer: &domain.ImageIdentifier{
 				Image: "image-test", Version: "version-test",
 			},
 			err: nil,
@@ -297,7 +297,7 @@ func TestFindCommand(t *testing.T) {
 		},
 		Then{
 			active: logic.Indeterminate,
-			imageVer: domain.ImageIdentifier{
+			imageVer: &domain.ImageIdentifier{
 				Image: "image-test", Version: "",
 			},
 		},
@@ -333,7 +333,7 @@ func TestFindCommand(t *testing.T) {
 		},
 		Then{
 			active:   logic.Indeterminate,
-			imageVer: domain.ImageIdentifier{},
+			imageVer: nil,
 		},
 	))
 
@@ -356,7 +356,7 @@ func TestFindCommand(t *testing.T) {
 			Then{
 				err:      err,
 				active:   logic.Indeterminate,
-				imageVer: domain.ImageIdentifier{},
+				imageVer: nil,
 			},
 		))
 	}
@@ -445,14 +445,14 @@ func TestRunFindPlan(t *testing.T) {
 		log := logger.Null()
 		mock := mock.New(t)
 		mock.Impl.FindPlan = func(
-			ctx context.Context, active logic.Ternary, imageVer domain.ImageIdentifier,
+			ctx context.Context, active logic.Ternary, imageVer *domain.ImageIdentifier,
 			inTags []tags.Tag, outTags []tags.Tag,
 		) ([]plans.Detail, error) {
 			return expectedValue, nil
 		}
 
 		// arguments set up
-		imageVer := domain.ImageIdentifier{
+		imageVer := &domain.ImageIdentifier{
 			Image: "test-image", Version: "test-version",
 		}
 		input := []tags.Tag{{Key: "foo", Value: "bar"}}
@@ -478,14 +478,14 @@ func TestRunFindPlan(t *testing.T) {
 
 		mock := mock.New(t)
 		mock.Impl.FindPlan = func(
-			ctx context.Context, active logic.Ternary, imageVer domain.ImageIdentifier,
+			ctx context.Context, active logic.Ternary, imageVer *domain.ImageIdentifier,
 			inTags []tags.Tag, outTags []tags.Tag,
 		) ([]plans.Detail, error) {
 			return nil, expectedError
 		}
 
 		// argements set up
-		imageVer := domain.ImageIdentifier{
+		imageVer := &domain.ImageIdentifier{
 			Image: "test-image", Version: "test-version",
 		}
 		input := []tags.Tag{{Key: "foo", Value: "bar"}}

--- a/cmd/knitd/handlers/plans.go
+++ b/cmd/knitd/handlers/plans.go
@@ -207,13 +207,12 @@ func FindPlanHandler(dbplan kdbplan.PlanInterface) echo.HandlerFunc {
 			result.OutTag = outTag
 
 			if paramImage != "" {
-				image, version, _ := strings.Cut(paramImage, ":")
-
-				if image == "" {
-					return nil, errIncorrectQueryImageVersion
+				imid := new(domain.ImageIdentifier)
+				err := imid.Parse(paramImage)
+				if err != nil {
+					return nil, err
 				}
-				result.ImageVer.Image = image
-				result.ImageVer.Version = version
+				result.ImageVer = *imid
 			}
 
 			return &result, nil

--- a/cmd/knitd/handlers/plans_test.go
+++ b/cmd/knitd/handlers/plans_test.go
@@ -1314,13 +1314,13 @@ func TestFind(t *testing.T) {
 		},
 		"When it receives query parameter, it converts it properly and passed it to PlanInterface.Find.": {
 			when: when{
-				request:     "/api/plans?active=true&image=image-1:ver-1&in_tag=key-1:val-1&in_tag=key-2:val-2&out_tag=key-3:val-3&out_tag=key-4:val-4",
+				request:     "/api/plans?active=true&image=repo:5000/image-1:ver-1&in_tag=key-1:val-1&in_tag=key-2:val-2&out_tag=key-3:val-3&out_tag=key-4:val-4",
 				queryResult: []*domain.Plan{}, err: nil,
 			},
 			then: then{
 				callResult: mockdb.PlanFindArgs{
 					Active:   logic.True,
-					ImageVer: domain.ImageIdentifier{Image: "image-1", Version: "ver-1"},
+					ImageVer: domain.ImageIdentifier{Image: "repo:5000/image-1", Version: "ver-1"},
 					InTag:    []domain.Tag{{Key: "key-1", Value: "val-1"}, {Key: "key-2", Value: "val-2"}},
 					OutTag:   []domain.Tag{{Key: "key-3", Value: "val-3"}, {Key: "key-4", Value: "val-4"}},
 				},
@@ -1354,13 +1354,13 @@ func TestFind(t *testing.T) {
 		},
 		"When version is not specified in the query,  it calls PlanInterface.Find with image only.": {
 			when: when{
-				request:     "/api/plans?image=image-1&in_tag=key-1:val-1&in_tag=key-2:val-2&out_tag=key-3:val-3&out_tag=key-4:val-4",
+				request:     "/api/plans?image=repo:5000/image-1&in_tag=key-1:val-1&in_tag=key-2:val-2&out_tag=key-3:val-3&out_tag=key-4:val-4",
 				queryResult: []*domain.Plan{}, err: nil,
 			},
 			then: then{
 				callResult: mockdb.PlanFindArgs{
 					Active:   logic.Indeterminate,
-					ImageVer: domain.ImageIdentifier{Image: "image-1", Version: ""},
+					ImageVer: domain.ImageIdentifier{Image: "repo:5000/image-1", Version: ""},
 					InTag:    []domain.Tag{{Key: "key-1", Value: "val-1"}, {Key: "key-2", Value: "val-2"}},
 					OutTag:   []domain.Tag{{Key: "key-3", Value: "val-3"}, {Key: "key-4", Value: "val-4"}},
 				},


### PR DESCRIPTION
## About This PR

By this change, `knit plan find --image` supports image names with port.

## What is Fixed

Before this change, parsing image name is broken.

To split the tag and rest, the old algorithms just cut with `:`. This is wrong because image name can be formatted in  `REPO:PORT/NAMESPACE/IMAGE:TAG`. In such case, the old algorithms split `REPO` and rest.

The new algorithms does split with `/` to detect `IMAGE:TAG` part, and split `:` for `IMAGE:TAG` part.