### PR TITLE
fix typo in `knit plan template`

### DIFF
--- a/cmd/knit/subcommands/plan/template/command.go
+++ b/cmd/knit/subcommands/plan/template/command.go
@@ -584,7 +584,7 @@ active (optional, mutable):
 			y.Bool(p.Active),
 		),
 		y.Entry(
-			y.Text("resouces", y.WithHeadComment(`
+			y.Text("resources", y.WithHeadComment(`
 resource (optional, mutable):
 Specify the resource , cpu or memory for example, requirements for this Plan.
 This value can be changed after the Plan is applied.


### PR DESCRIPTION
## About This PR

Plan definition yaml generated by `knit plan template` had typo.

The key should be `resources` but it was `resouces`.

Fix it.

### Related Issues

- closes #226