### PR TITLE
Make the missing edge visible.

### DIFF
--- a/web-console/src/components/LineageGraph.tsx
+++ b/web-console/src/components/LineageGraph.tsx
@@ -87,7 +87,7 @@ const RunNode: React.FC<NodeProps<Node<RunNodeValues, "runNode">>> = ({ data }) 
                 />
             </Box>
             {
-                0 < data.run.outputs.length &&
+                (0 < data.run.outputs.length || data.run.log !== undefined) &&
                 <Handle type="source" position={Position.Bottom} isConnectable={false} />
             }
         </>


### PR DESCRIPTION
RunItem had not output handle when a Run had a log as its single output. So, the edge between RunItem and log Data was not visible.

Fixed.

![image](https://github.com/user-attachments/assets/003762f6-f011-484a-97be-f7576d3bb6df)


## Related issue

- closes #266 