### PR TITLE
Feature/#267/web console version number clickable

### DIFF
--- a/web-console/src/app.tsx
+++ b/web-console/src/app.tsx
@@ -3,10 +3,13 @@ import Backdrop from "@mui/material/Backdrop";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
+import Divider from "@mui/material/Divider";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import React, { useCallback, useEffect, useState } from "react";
@@ -17,10 +20,9 @@ import { PlanService } from "./api/services/planService";
 import { RunService } from "./api/services/runService";
 import DataList from "./components/DataList";
 import LineageGraph from "./components/LineageGraph";
+import PlanGraph from "./components/PlanGraph";
 import PlanList from "./components/PlanList";
 import RunList from "./components/RunList";
-import PlanGraph from "./components/PlanGraph";
-import { Divider, Tooltip, Typography } from "@mui/material";
 
 
 const AppTabs: React.FC<{

--- a/web-console/src/app.tsx
+++ b/web-console/src/app.tsx
@@ -20,7 +20,7 @@ import LineageGraph from "./components/LineageGraph";
 import PlanList from "./components/PlanList";
 import RunList from "./components/RunList";
 import PlanGraph from "./components/PlanGraph";
-import { Tooltip, Typography } from "@mui/material";
+import { Divider, Tooltip, Typography } from "@mui/material";
 
 
 const AppTabs: React.FC<{
@@ -98,7 +98,7 @@ const AppTabs: React.FC<{
                     </Box>
                     <Tooltip title={showCommitHash ? "Hide commit hash" : "Show commit hash"}>
                         <Box
-                            sx={{ display: "flex", alignItems: "center" }}
+                            sx={{ display: "flex", alignItems: "center", cursor: "pointer", marginRight: 2 }}
                             onClick={() => {
                                 setShowCommitHash((prev) => !prev)
                             }}
@@ -110,6 +110,7 @@ const AppTabs: React.FC<{
                             }
                         </Box>
                     </Tooltip>
+                    <Divider orientation="vertical" flexItem />
                     <Button href="/licenses.txt">OSS licenses</Button>
                 </Stack>
                 <Stack direction="column" spacing={2}>


### PR DESCRIPTION
Change the mouse cursor hovering version number to "poiner", to make clear that version number is clickable.

## Realted Issue

- closes #267 