### PR TITLE
Feature/#285/projection run adapt to data purging

### DIFF
--- a/pkg/domain/run/db/postgres/run.go
+++ b/pkg/domain/run/db/postgres/run.go
@@ -143,54 +143,7 @@ func (m *runPG) New(ctx context.Context) ([]string, *domain.ProjectionTrigger, e
 	}
 	defer tx.Rollback(ctx)
 
-	// step 1. determine plan & lock the plan + nominated data
-	var planId string
-	var _dn int
-	if err := tx.QueryRow(
-		ctx,
-		`
-		with
-		"mp" as (
-			select distinct "input_id" from "nomination" where "updated"
-		),
-		"pids" as (
-			select "plan_id" from "plan_image"
-
-			intersect
-
-			select "plan_id" from "input"
-			inner join "mp" using ("input_id")
-		),
-		"plan" as (
-			select "plan_id" from "plan" inner join "pids" using("plan_id")
-			for update of "plan" skip locked
-			limit 1
-		),
-		"rel_mp" as (
-			select "input_id" from "input" inner join "plan" using("plan_id")
-		),
-		"n" as (
-			select "knit_id" from "nomination" inner join "rel_mp" using("input_id")
-		),
-		"d" as (
-			select "knit_id" from "data" inner join "n" using("knit_id")
-			order by "knit_id" for share of "data"
-		),
-		"dn" as (select count("knit_id") as "locked_data" from "d")
-		select "plan_id", "locked_data" from "plan", "dn"
-		`,
-		// to lock data, we count (scanning all rows) them.
-		//
-		// This operation needs preventing update/delete data, so we take lock on data with "for share".
-		// But not need to occupy them; only referencing them is Okay, multiple New's can run in parallel.
-	).Scan(&planId, &_dn); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil, nil // nothing to do
-		}
-		return nil, nil, err
-	}
-
-	// step 2. fetch nominations
+	// step 1. determine plan & lock the plan
 	nominations := map[int][]string{}     // mountpointId -> knitIds, nominated
 	var trigger *domain.ProjectionTrigger // mountpontId, knitId nominated
 	{
@@ -198,13 +151,33 @@ func (m *runPG) New(ctx context.Context) ([]string, *domain.ProjectionTrigger, e
 			ctx,
 			`
 			with
+			"mp" as (
+				select distinct "input_id" from "nomination" where "updated"
+			),
+			"pids" as (
+				select "plan_id" from "plan_image"
+
+				intersect
+
+				select "plan_id" from "input"
+				inner join "mp" using ("input_id")
+			),
+			"plan" as (
+				select "plan_id" from "plan" inner join "pids" using("plan_id")
+				for update of "plan" skip locked
+				limit 1
+			),
 			"input" as (
 				select "input_id" from "input"
-				where "plan_id" = $1
+				where "plan_id" in (table "plan")
 			),
 			"nom" as (
-				select "input_id", "knit_id", "updated" from "nomination"
+				select "input_id", "knit_id", "updated"
+				from "nomination"
 				inner join "input" using ("input_id")
+				inner join "data" using ("knit_id")
+				order by "knit_id"
+				for share of "data", "nomination"
 			),
 			"new" as (
 				select "input_id", "knit_id", "updated" from "nom"
@@ -216,15 +189,13 @@ func (m *runPG) New(ctx context.Context) ([]string, *domain.ProjectionTrigger, e
 			)
 			select "input_id", "knit_id", "updated"
 			from "input"
-			left outer join (table "known" union table "new") as "n" using("input_id")
+			left outer join (table "known" union table "new") as "n" using ("input_id")
 			`,
-			planId,
 		)
 		if err != nil {
 			return nil, nil, err
 		}
 		defer rows.Close()
-
 		for rows.Next() {
 			var mountpointId int
 			var knitId *string
@@ -243,17 +214,29 @@ func (m *runPG) New(ctx context.Context) ([]string, *domain.ProjectionTrigger, e
 
 			if updated != nil && *updated {
 				trigger = &domain.ProjectionTrigger{
-					PlanId: planId, InputId: mountpointId, KnitId: *knitId,
+					InputId: mountpointId, KnitId: *knitId,
 				}
 			} else {
 				nominations[mountpointId] = append(k, *knitId)
 			}
 		}
-		rows.Close()
 	}
 
 	if trigger == nil {
 		return nil, nil, nil
+	}
+
+	// step 2. fetch & lock nominations, lock data
+	{
+		var planId string
+		if err := tx.QueryRow(
+			ctx,
+			`select "plan_id" from "input" where "input_id" = $1`,
+			trigger.InputId,
+		).Scan(&planId); err != nil {
+			return nil, nil, err
+		}
+		trigger.PlanId = planId
 	}
 
 	// step 3. perform projection.

--- a/pkg/domain/run/db/postgres/run.go
+++ b/pkg/domain/run/db/postgres/run.go
@@ -802,10 +802,16 @@ func (m *runPG) complementData(ctx context.Context, conn kpool.Queryer, runId st
 			_, err := conn.Exec(
 				ctx,
 				`
-				insert into "data" ("knit_id", "volume_ref", "output_id", "run_id", "plan_id")
-				values ($1, $2, $3, $4, $5)
+				with "data" as (
+					insert into "data" ("knit_id", "output_id", "run_id", "plan_id")
+					values ($1, $2, $3, $4)
+					returning "knit_id"
+				)
+				insert into "volume_ref" ("knit_id", "volume_ref")
+				select "knit_id", $5 as "volume_ref"
+				from "data"
 				`,
-				knitId, volumeRef, spec.outputId, spec.runId, spec.planId,
+				knitId, spec.outputId, spec.runId, spec.planId, volumeRef,
 			)
 			if err != nil {
 				return err

--- a/pkg/domain/run/db/postgres/tests/new_test.go
+++ b/pkg/domain/run/db/postgres/tests/new_test.go
@@ -94,11 +94,6 @@ func TestRun_New(t *testing.T) {
 
 	type expectation struct {
 		newRuns []runExpectation
-
-		// - key: plan id
-		//
-		// - value: knit ids which are to be locked when plan in key is locked.
-		planLockData map[string][]string
 	}
 
 	type testcase struct {
@@ -309,8 +304,7 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{},
-				newRuns:      []runExpectation{}, // empty
+				newRuns: []runExpectation{}, // empty
 			},
 		},
 		"Not enough data are given, no projections are performed": {
@@ -371,11 +365,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{}, // empty
 			},
 		},
@@ -471,12 +460,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-						th.Padding36("data:1-2/run:1-2/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{
 					{
 						body: tables.Run{
@@ -607,12 +590,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-						th.Padding36("data:1-2/run:1-2/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{
 					{
 						body: tables.Run{
@@ -721,14 +698,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-					th.Padding36("plan:3/split"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{
 					{
 						body: tables.Run{
@@ -942,16 +911,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-						th.Padding36("data:1-2/run:1-2/uploaded//out"),
-						th.Padding36("data:1-3/run:1-3/uploaded//out"),
-					},
-					th.Padding36("plan:3/split"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{
 					{
 						body: tables.Run{
@@ -1374,14 +1333,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-					th.Padding36("plan:3/split"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{
 					{
 						body: tables.Run{
@@ -1535,15 +1486,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-						th.Padding36("data:1-2/run:1-2/uploaded//out"),
-					},
-					th.Padding36("plan:3/split"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{
 					{
 						body: tables.Run{
@@ -1698,14 +1640,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-					th.Padding36("plan:3/split"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{}, // empty
 			},
 		},
@@ -1793,12 +1727,6 @@ func TestRun_New(t *testing.T) {
 				},
 			},
 			then: expectation{
-				planLockData: map[string][]string{
-					th.Padding36("plan:2/preprocessing"): {
-						th.Padding36("data:1-1/run:1-1/uploaded//out"),
-						th.Padding36("data:1-2/run:1-2/uploaded//out"),
-					},
-				},
 				newRuns: []runExpectation{}, // empty
 			},
 		},
@@ -1847,8 +1775,16 @@ func TestRun_New(t *testing.T) {
 					}
 				}
 
-				// interest #2 : which data are locked?
+				if !cmp.SliceSubsetWith(plansWithUpdatedNomination, lockedPlanId, cmp.EqEq[string]) {
+					t.Errorf(
+						"unexpected plan is locked:\n- locked: %v\n- plan have updated input: %v",
+						lockedPlanId, plansWithUpdatedNomination,
+					)
+				}
 
+				// interest #2 : which Data are locked?
+
+				// - actual Data locked
 				lockedKnitId := try.To(scanner.New[string]().QueryAll(
 					ctx, conn,
 					`
@@ -1858,13 +1794,7 @@ func TestRun_New(t *testing.T) {
 					`,
 				)).OrFatal(t)
 
-				if !cmp.SliceSubsetWith(plansWithUpdatedNomination, lockedPlanId, cmp.EqEq[string]) {
-					t.Errorf(
-						"unexpected plan is locked:\n- locked: %v\n- plan have updated input: %v",
-						lockedPlanId, plansWithUpdatedNomination,
-					)
-				}
-
+				// - expected Data locked. They are Data nominated from locked Plans.
 				knitIdNominatedForLockedPlan := try.To(scanner.New[string]().QueryAll(
 					ctx, conn,
 					`
@@ -1877,10 +1807,10 @@ func TestRun_New(t *testing.T) {
 					lockedPlanId,
 				)).OrFatal(t)
 
-				if !cmp.SliceContentEq(knitIdNominatedForLockedPlan, lockedKnitId) {
+				if !cmp.SliceContentEq(lockedKnitId, knitIdNominatedForLockedPlan) {
 					t.Errorf(
-						"unexpected lock: data:\nactual   = %v\nexpected = %v",
-						knitIdNominatedForLockedPlan, lockedKnitId,
+						"unexpected lock: data:\nactual   = %v\nexpected = %v\n(for plan %v)",
+						lockedKnitId, knitIdNominatedForLockedPlan, lockedPlanId,
 					)
 				}
 			})


### PR DESCRIPTION
- on creating new Runs, insert into VolumeRef for the Runs' output Data.
- make sure to lock nominations for VolumeRefs to be protected from purging.

## Related Issues

- closes #285 