### PR TITLE
Feature/#287/adapt gcloop to data purge

### DIFF
--- a/pkg/domain/garbage/db/postgres/garbage.go
+++ b/pkg/domain/garbage/db/postgres/garbage.go
@@ -28,7 +28,7 @@ func (g *pgGarbage) Pop(ctx context.Context, callback func(types.Garbage) error)
 		ctx,
 		`
 		with "del_id" as (
-			select "knit_id","volume_ref" from "garbage" limit 1 for update skip locked
+			select "knit_id", "volume_ref" from "garbage" limit 1 for update skip locked
 		),
 		"del_garbage" as (
 			delete from "garbage"
@@ -56,7 +56,26 @@ func (g *pgGarbage) Pop(ctx context.Context, callback func(types.Garbage) error)
 		return false, err
 	}
 
-	if pop && callback != nil {
+	if !pop {
+		return false, nil
+	}
+
+	if _, err := tx.Exec(
+		ctx,
+		`
+		with
+		"dep" as (
+			select 1 from "data" where "knit_id" = $1
+		)
+		delete from "knit_id"
+		where "knit_id" = $1 and not exists (select 1 from "dep")
+		`,
+		knitId,
+	); err != nil {
+		return false, err
+	}
+
+	if callback != nil {
 		if err := callback(types.Garbage{KnitId: knitId, VolumeRef: volumeRef}); err != nil {
 			return false, err
 		}

--- a/pkg/domain/garbage/db/postgres/garbage.go
+++ b/pkg/domain/garbage/db/postgres/garbage.go
@@ -33,10 +33,6 @@ func (g *pgGarbage) Pop(ctx context.Context, callback func(types.Garbage) error)
 		"del_garbage" as (
 			delete from "garbage"
 			where "knit_id" in (select "knit_id" from "del_id")
-		),
-		"del_knit" as (
-			delete from "knit_id"
-			where "knit_id" in (select "knit_id" from "del_id")
 		)
 		select * from "del_id";
 		`,
@@ -46,11 +42,11 @@ func (g *pgGarbage) Pop(ctx context.Context, callback func(types.Garbage) error)
 	}
 	defer rows.Close()
 
-	var KnitId string
-	var VolumeRef string
+	var knitId string
+	var volumeRef string
 	pop := false
 	for rows.Next() {
-		err = rows.Scan(&KnitId, &VolumeRef)
+		err = rows.Scan(&knitId, &volumeRef)
 		if err != nil {
 			return false, err
 		}
@@ -61,7 +57,7 @@ func (g *pgGarbage) Pop(ctx context.Context, callback func(types.Garbage) error)
 	}
 
 	if pop && callback != nil {
-		if err := callback(types.Garbage{KnitId: KnitId, VolumeRef: VolumeRef}); err != nil {
+		if err := callback(types.Garbage{KnitId: knitId, VolumeRef: volumeRef}); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/domain/garbage/db/postgres/garbage_test.go
+++ b/pkg/domain/garbage/db/postgres/garbage_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 
 	"github.com/opst/knitfab/pkg/conn/db/postgres/pool/testenv"
+	"github.com/opst/knitfab/pkg/conn/db/postgres/scanner"
 	"github.com/opst/knitfab/pkg/domain"
 	kpggbg "github.com/opst/knitfab/pkg/domain/garbage/db/postgres"
+	"github.com/opst/knitfab/pkg/domain/internal/db/postgres/testhelpers"
 	. "github.com/opst/knitfab/pkg/domain/internal/db/postgres/testhelpers"
+	"github.com/opst/knitfab/pkg/utils/cmp"
 	"github.com/opst/knitfab/pkg/utils/try"
 )
 
@@ -45,13 +48,13 @@ func TestGarbage_Pop(t *testing.T) {
 		pop, err := testee.Pop(
 			ctx,
 			func(g domain.Garbage) error {
-				if g == expectedGarbage {
-					return nil
+				if g != expectedGarbage {
+					t.Errorf(
+						"argument of callback function does not match.(KnitId, VolumeRef = %v, %v)",
+						g.KnitId, g.VolumeRef,
+					)
 				}
-				return fmt.Errorf(
-					"argument of callback function does not match.(KnitId, VolumeRef= %v,%v)",
-					g.KnitId, g.VolumeRef,
-				)
+				return nil
 			},
 		)
 		// [Verification]
@@ -60,28 +63,28 @@ func TestGarbage_Pop(t *testing.T) {
 		// The record count of the knit_id table and the garbage table becomes 0.
 		if !pop || err != nil {
 			t.Errorf(
-				"return value of test function does not match. (pop,err =%v,%v)",
+				"return value of test function does not match. (pop, err = %v, %v)",
 				pop, err,
 			)
 		}
-		var countKnitId int
-		var countGarbage int
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "knit_id";`,
-		).Scan(&countKnitId); err != nil {
-			t.Fatalf("counting record of knit_id is failed. %v", err)
-		}
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "garbage";`,
-		).Scan(&countGarbage); err != nil {
-			t.Fatalf("counting record of gargabe is failed. %v", err)
-		}
-		if countKnitId != 0 || countGarbage != 0 {
+		knitIds := try.To(
+			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
+		).OrFatal(t)
+
+		if want := []string{expectedGarbage.KnitId}; !cmp.SliceContentEq(knitIds, want) {
 			t.Errorf(
-				"record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage,
+				"record of knit_id table does not match. got: %v, want: %v",
+				knitIds, want,
+			)
+		}
+		garbage := try.To(
+			scanner.New[domain.Garbage]().QueryAll(ctx, conn, `table "garbage"`),
+		).OrFatal(t)
+
+		if want := []domain.Garbage{}; !cmp.SliceContentEq(garbage, want) {
+			t.Errorf(
+				"record count does not match. got: %v, want: %v",
+				garbage, want,
 			)
 		}
 	})
@@ -96,46 +99,48 @@ func TestGarbage_Pop(t *testing.T) {
 		defer conn.Release()
 		if _, err := conn.Exec(
 			ctx,
-			`insert into "knit_id" ("knit_id") values ('knit-1')`,
+			`insert into "knit_id" ("knit_id") values ($1)`,
+			testhelpers.Padding36("knit-1"),
 		); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := conn.Exec(
 			ctx,
-			`insert into "garbage" ("knit_id","volume_ref") values ('knit-1','garbage-1')`,
+			`insert into "garbage" ("knit_id", "volume_ref") values ($1, $2)`,
+			testhelpers.Padding36("knit-1"), "garbage-1",
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		testee := kpggbg.New(pgpool)
 		pop, err := testee.Pop(ctx, nil)
-		//[Verification]
+		// [Verification]
 		// The first return value "pop" of the target function is true, and the second return value is nil.
 		// The record count of the "knit_id" table and the "garbage" table becomes 0.
 		if !pop || err != nil {
 			t.Errorf(
-				"return value of test function does not match. (pop,err =%v,%v)",
+				"return value of test function does not match. (pop, err = %v, %v)",
 				pop, err,
 			)
 		}
-		var countKnitId int
-		var countGarbage int
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "knit_id";`,
-		).Scan(&countKnitId); err != nil {
-			t.Fatalf("counting record of knit_id is failed. %v", err)
+
+		knitIds := try.To(
+			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
+		).OrFatal(t)
+
+		if want := []string{
+			testhelpers.Padding36("knit-1"),
+		}; !cmp.SliceContentEq(knitIds, want) {
+			t.Errorf("record of knit_id table does not match. got: %v, want: %v", knitIds, want)
 		}
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "garbage";`,
-		).Scan(&countGarbage); err != nil {
-			t.Fatalf("counting record of gargabe is failed. %v", err)
-		}
-		if countKnitId != 0 || countGarbage != 0 {
+
+		garbage := try.To(
+			scanner.New[domain.Garbage]().QueryAll(ctx, conn, `table "garbage"`),
+		).OrFatal(t)
+		if want := []domain.Garbage{}; !cmp.SliceContentEq(garbage, want) {
 			t.Errorf(
-				"record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage,
+				"record count does not match. want: %v, got: %v",
+				want, garbage,
 			)
 		}
 	})
@@ -151,7 +156,8 @@ func TestGarbage_Pop(t *testing.T) {
 		// Insert record into the knit_id table
 		if _, err := conn.Exec(
 			ctx,
-			`insert into "knit_id" ("knit_id") values ('knit-1')`,
+			`insert into "knit_id" ("knit_id") values ($1)`,
+			testhelpers.Padding36("knit-1"),
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -162,7 +168,7 @@ func TestGarbage_Pop(t *testing.T) {
 			ctx,
 			func(domain.Garbage) error { return expectedError },
 		)
-		//[Verification]
+		// [Verification]
 		// The first return value "pop" of the target function is false, and the second return value is nil.
 		if pop || err != nil {
 			t.Errorf(
@@ -175,13 +181,16 @@ func TestGarbage_Pop(t *testing.T) {
 			t.Error("callback was used")
 		}
 		// The record count of the knit_id table remains unchanged.
-		var count int
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "knit_id";`).Scan(&count); err != nil {
-			t.Fatalf("count query is failed. %v", err)
-		}
-		if count != 1 {
-			t.Errorf("record count of knit_id table changes! record count: %v", count)
+		knitIds := try.To(
+			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
+		).OrFatal(t)
+		if want := []string{
+			testhelpers.Padding36("knit-1"),
+		}; !cmp.SliceContentEq(knitIds, want) {
+			t.Errorf(
+				"record count of knit_id table changes! want: %v, got: %v",
+				want, knitIds,
+			)
 		}
 	})
 	t.Run("When the callback function returns an error, the entire function becomes an error", func(t *testing.T) {
@@ -194,13 +203,15 @@ func TestGarbage_Pop(t *testing.T) {
 		defer conn.Release()
 		if _, err := conn.Exec(
 			ctx,
-			`insert into "knit_id" ("knit_id") values ('knit-1')`,
+			`insert into "knit_id" ("knit_id") values ($1)`,
+			testhelpers.Padding36("knit-1"),
 		); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := conn.Exec(
 			ctx,
-			`insert into "garbage" ("knit_id","volume_ref") values ('knit-1','garbage-1')`,
+			`insert into "garbage" ("knit_id", "volume_ref") values ($1, $2)`,
+			testhelpers.Padding36("knit-1"), "garbage-1",
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -215,27 +226,34 @@ func TestGarbage_Pop(t *testing.T) {
 		if pop || !errors.Is(err, expectedError) {
 			t.Errorf(
 				"return value of test function does not match. (pop,err) = (%v, %v)",
-				pop, err)
+				pop, err,
+			)
 		}
 		// The record count of the knit_id table and the garbage table remains unchanged (still 1).
-		var countKnitId int
-		var countGarbage int
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "knit_id";`,
-		).Scan(&countKnitId); err != nil {
-			t.Fatalf("counting record of knit_id is failed. %v", err)
-		}
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "garbage";`,
-		).Scan(&countGarbage); err != nil {
-			t.Fatalf("counting record of gargabe is failed. %v", err)
-		}
-		if countKnitId != 1 || countGarbage != 1 {
+		knitIds := try.To(
+			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
+		).OrFatal(t)
+		if want := []string{
+			testhelpers.Padding36("knit-1"),
+		}; !cmp.SliceContentEq(knitIds, want) {
 			t.Errorf(
-				"record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage,
+				"record count of knit_id table changes! want: %v, got: %v",
+				want, knitIds,
+			)
+		}
+
+		garbage := try.To(
+			scanner.New[domain.Garbage]().QueryAll(ctx, conn, `table "garbage";`),
+		).OrFatal(t)
+		if want := []domain.Garbage{
+			{
+				KnitId:    testhelpers.Padding36("knit-1"),
+				VolumeRef: "garbage-1",
+			},
+		}; !cmp.SliceContentEq(garbage, want) {
+			t.Errorf(
+				"record count of garbage table changes! want: %v, got: %v",
+				want, garbage,
 			)
 		}
 	})
@@ -251,13 +269,15 @@ func TestGarbage_Pop(t *testing.T) {
 
 		if _, err := conn.Exec(
 			ctx,
-			`insert into "knit_id" ("knit_id") values ('knit-1')`,
+			`insert into "knit_id" ("knit_id") values ($1)`,
+			testhelpers.Padding36("knit-1"),
 		); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := conn.Exec(
 			ctx,
-			`insert into "garbage" ("knit_id","volume_ref") values ('knit-1','garbage-1')`,
+			`insert into "garbage" ("knit_id","volume_ref") values ($1, $2)`,
+			testhelpers.Padding36("knit-1"), "garbage-1",
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -290,24 +310,32 @@ func TestGarbage_Pop(t *testing.T) {
 			t.Error("callback was used")
 		}
 		// The record count of the knit_id table and the garbage table remains unchanged (still 1)
-		var countKnitId int
-		var countGarbage int
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "knit_id";`,
-		).Scan(&countKnitId); err != nil {
-			t.Fatalf("counting record of knit_id is failed. %v", err)
-		}
-		if err := conn.QueryRow(
-			ctx,
-			`select count("knit_id") from "garbage";`,
-		).Scan(&countGarbage); err != nil {
-			t.Fatalf("counting record of gargabe is failed. %v", err)
-		}
-		if countKnitId != 1 || countGarbage != 1 {
+		knitIds := try.To(
+			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
+		).OrFatal(t)
+
+		if want := []string{
+			testhelpers.Padding36("knit-1"),
+		}; !cmp.SliceContentEq(knitIds, want) {
 			t.Errorf(
-				"record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage,
+				"record count of knit_id table changes! want: %v, got: %v",
+				want, knitIds,
+			)
+		}
+
+		garbage := try.To(
+			scanner.New[domain.Garbage]().QueryAll(ctx, conn, `table "garbage"`),
+		).OrFatal(t)
+
+		if want := []domain.Garbage{
+			{
+				KnitId:    testhelpers.Padding36("knit-1"),
+				VolumeRef: "garbage-1",
+			},
+		}; !cmp.SliceContentEq(garbage, want) {
+			t.Errorf(
+				"record count of garbage table changes! want: %v, got: %v",
+				want, garbage,
 			)
 		}
 	})

--- a/pkg/domain/garbage/db/postgres/garbage_test.go
+++ b/pkg/domain/garbage/db/postgres/garbage_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/opst/knitfab/pkg/conn/db/postgres/scanner"
 	"github.com/opst/knitfab/pkg/domain"
 	kpggbg "github.com/opst/knitfab/pkg/domain/garbage/db/postgres"
+	"github.com/opst/knitfab/pkg/domain/internal/db/postgres/tables"
 	"github.com/opst/knitfab/pkg/domain/internal/db/postgres/testhelpers"
-	. "github.com/opst/knitfab/pkg/domain/internal/db/postgres/testhelpers"
 	"github.com/opst/knitfab/pkg/utils/cmp"
+	"github.com/opst/knitfab/pkg/utils/pointer"
 	"github.com/opst/knitfab/pkg/utils/try"
 )
 
@@ -27,20 +28,17 @@ func TestGarbage_Pop(t *testing.T) {
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
 
-		expectedGarbage := domain.Garbage{KnitId: Padding36("knit-1"), VolumeRef: "garbage-1"}
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "knit_id" ("knit_id") values ($1)`,
-			expectedGarbage.KnitId,
-		); err != nil {
-			t.Fatal(err)
+		expectedGarbage := domain.Garbage{
+			KnitId:    testhelpers.Padding36("knit-1"),
+			VolumeRef: "garbage-1",
 		}
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "garbage" ("knit_id", "volume_ref") values ($1, $2)`,
-			expectedGarbage.KnitId,
-			expectedGarbage.VolumeRef,
-		); err != nil {
+		given := tables.Operation{
+			Garbage: []tables.Garbage{
+				tables.Garbage(expectedGarbage),
+			},
+		}
+
+		if err := given.ApplyWithConn(ctx, conn); err != nil {
 			t.Fatal(err)
 		}
 
@@ -71,7 +69,119 @@ func TestGarbage_Pop(t *testing.T) {
 			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
 		).OrFatal(t)
 
-		if want := []string{expectedGarbage.KnitId}; !cmp.SliceContentEq(knitIds, want) {
+		if want := []string{}; !cmp.SliceContentEq(knitIds, want) {
+			t.Errorf(
+				"record of knit_id table does not match. got: %v, want: %v",
+				knitIds, want,
+			)
+		}
+		garbage := try.To(
+			scanner.New[domain.Garbage]().QueryAll(ctx, conn, `table "garbage"`),
+		).OrFatal(t)
+
+		if want := []domain.Garbage{}; !cmp.SliceContentEq(garbage, want) {
+			t.Errorf(
+				"record count does not match. got: %v, want: %v",
+				garbage, want,
+			)
+		}
+	})
+
+	t.Run("If there is 1 record in garbage, that record will be popped; do not delete knit_id if there are Data referencing it", func(t *testing.T) {
+		// [Preparation]
+		// Connect to the database
+		// Insert 1 record into the knit_id table and the garbage table
+		ctx := context.Background()
+		pgpool := poolBroaker.GetPool(ctx, t)
+		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
+		defer conn.Release()
+
+		expectedGarbage := domain.Garbage{
+			KnitId:    testhelpers.Padding36("knit-1"),
+			VolumeRef: "garbage-1",
+		}
+		given := tables.Operation{
+			Plan: []tables.Plan{
+				{
+					PlanId: testhelpers.Padding36("plan-1"),
+					Active: true,
+					Hash:   "hash-1",
+				},
+			},
+			PlanPseudo: []tables.PlanPseudo{
+				{
+					PlanId: testhelpers.Padding36("plan-1"),
+					Name:   testhelpers.Padding36("pseudo-1"),
+				},
+			},
+			Outputs: map[tables.Output]tables.OutputAttr{
+				{
+					OutputId: 1,
+					PlanId:   testhelpers.Padding36("plan-1"),
+				}: {},
+			},
+
+			Steps: []tables.Step{
+				{
+					Run: tables.Run{
+						RunId:                 testhelpers.Padding36("run-1"),
+						PlanId:                testhelpers.Padding36("plan-1"),
+						Status:                domain.Done,
+						LifecycleSuspendUntil: try.To(testhelpers.ISO8601("2021-01-01T00:00:00Z")).OrFatal(t),
+						UpdatedAt:             try.To(testhelpers.ISO8601("2021-01-02T00:00:00Z")).OrFatal(t),
+					},
+					Outcomes: map[tables.Data]tables.DataAttibutes{
+						{
+							KnitId:   testhelpers.Padding36("knit-1"),
+							PlanId:   testhelpers.Padding36("plan-1"),
+							OutputId: 1,
+							RunId:    testhelpers.Padding36("run-1"),
+						}: {
+							Timestamp: pointer.Ref(try.To(testhelpers.ISO8601("2021-01-01T00:00:00Z")).OrFatal(t)),
+						},
+					},
+				},
+			},
+
+			Garbage: []tables.Garbage{
+				tables.Garbage(expectedGarbage),
+			},
+		}
+
+		if err := given.ApplyWithConn(ctx, conn); err != nil {
+			t.Fatal(err)
+		}
+
+		testee := kpggbg.New(pgpool)
+		pop, err := testee.Pop(
+			ctx,
+			func(g domain.Garbage) error {
+				if g != expectedGarbage {
+					t.Errorf(
+						"argument of callback function does not match.(KnitId, VolumeRef = %v, %v)",
+						g.KnitId, g.VolumeRef,
+					)
+				}
+				return nil
+			},
+		)
+		// [Verification]
+		// The record to be popped is passed as an argument to the callback function.
+		// The first return value "pop" of the target function is true, and the second return value is nil.
+		// The record count of the knit_id table and the garbage table becomes 0.
+		if !pop || err != nil {
+			t.Errorf(
+				"return value of test function does not match. (pop, err = %v, %v)",
+				pop, err,
+			)
+		}
+		knitIds := try.To(
+			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
+		).OrFatal(t)
+
+		if want := []string{
+			testhelpers.Padding36("knit-1"),
+		}; !cmp.SliceContentEq(knitIds, want) {
 			t.Errorf(
 				"record of knit_id table does not match. got: %v, want: %v",
 				knitIds, want,
@@ -97,18 +207,17 @@ func TestGarbage_Pop(t *testing.T) {
 		pgpool := poolBroaker.GetPool(ctx, t)
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "knit_id" ("knit_id") values ($1)`,
-			testhelpers.Padding36("knit-1"),
-		); err != nil {
-			t.Fatal(err)
+
+		given := tables.Operation{
+			Garbage: []tables.Garbage{
+				{
+					KnitId:    testhelpers.Padding36("knit-1"),
+					VolumeRef: "garbage-1",
+				},
+			},
 		}
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "garbage" ("knit_id", "volume_ref") values ($1, $2)`,
-			testhelpers.Padding36("knit-1"), "garbage-1",
-		); err != nil {
+
+		if err := given.ApplyWithConn(ctx, conn); err != nil {
 			t.Fatal(err)
 		}
 
@@ -128,9 +237,7 @@ func TestGarbage_Pop(t *testing.T) {
 			scanner.New[string]().QueryAll(ctx, conn, `table "knit_id"`),
 		).OrFatal(t)
 
-		if want := []string{
-			testhelpers.Padding36("knit-1"),
-		}; !cmp.SliceContentEq(knitIds, want) {
+		if want := []string{}; !cmp.SliceContentEq(knitIds, want) {
 			t.Errorf("record of knit_id table does not match. got: %v, want: %v", knitIds, want)
 		}
 
@@ -154,11 +261,12 @@ func TestGarbage_Pop(t *testing.T) {
 		defer conn.Release()
 
 		// Insert record into the knit_id table
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "knit_id" ("knit_id") values ($1)`,
-			testhelpers.Padding36("knit-1"),
-		); err != nil {
+		given := tables.Operation{
+			KnitId: []string{
+				testhelpers.Padding36("knit-1"),
+			},
+		}
+		if err := given.ApplyWithConn(ctx, conn); err != nil {
 			t.Fatal(err)
 		}
 
@@ -201,20 +309,20 @@ func TestGarbage_Pop(t *testing.T) {
 		pgpool := poolBroaker.GetPool(ctx, t)
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "knit_id" ("knit_id") values ($1)`,
-			testhelpers.Padding36("knit-1"),
-		); err != nil {
+
+		given := tables.Operation{
+			Garbage: []tables.Garbage{
+				{
+					KnitId:    testhelpers.Padding36("knit-1"),
+					VolumeRef: "garbage-1",
+				},
+			},
+		}
+
+		if err := given.ApplyWithConn(ctx, conn); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "garbage" ("knit_id", "volume_ref") values ($1, $2)`,
-			testhelpers.Padding36("knit-1"), "garbage-1",
-		); err != nil {
-			t.Fatal(err)
-		}
+
 		expectedError := fmt.Errorf("callback causes expected error")
 		testee := kpggbg.New(pgpool)
 		pop, err := testee.Pop(
@@ -267,18 +375,15 @@ func TestGarbage_Pop(t *testing.T) {
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
 
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "knit_id" ("knit_id") values ($1)`,
-			testhelpers.Padding36("knit-1"),
-		); err != nil {
-			t.Fatal(err)
+		given := tables.Operation{
+			Garbage: []tables.Garbage{
+				{
+					KnitId:    testhelpers.Padding36("knit-1"),
+					VolumeRef: "garbage-1",
+				},
+			},
 		}
-		if _, err := conn.Exec(
-			ctx,
-			`insert into "garbage" ("knit_id","volume_ref") values ($1, $2)`,
-			testhelpers.Padding36("knit-1"), "garbage-1",
-		); err != nil {
+		if err := given.ApplyWithConn(ctx, conn); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/domain/garbage/db/postgres/garbage_test.go
+++ b/pkg/domain/garbage/db/postgres/garbage_test.go
@@ -16,23 +16,25 @@ import (
 func TestGarbage_Pop(t *testing.T) {
 	poolBroaker := testenv.NewPoolBroaker(context.Background(), t)
 	t.Run("If there is 1 record in garbage, that record will be popped", func(t *testing.T) {
-		//[Preparation]
-		//Connect to the database
-		//Insert 1 record into the knit_id table and the garbage table
+		// [Preparation]
+		// Connect to the database
+		// Insert 1 record into the knit_id table and the garbage table
 		ctx := context.Background()
 		pgpool := poolBroaker.GetPool(ctx, t)
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
 
 		expectedGarbage := domain.Garbage{KnitId: Padding36("knit-1"), VolumeRef: "garbage-1"}
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "knit_id" ("knit_id") values ($1)`,
 			expectedGarbage.KnitId,
 		); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := conn.Exec(ctx,
-			`insert into "garbage" ("knit_id","volume_ref") values ($1,$2)`,
+		if _, err := conn.Exec(
+			ctx,
+			`insert into "garbage" ("knit_id", "volume_ref") values ($1, $2)`,
 			expectedGarbage.KnitId,
 			expectedGarbage.VolumeRef,
 		); err != nil {
@@ -40,54 +42,66 @@ func TestGarbage_Pop(t *testing.T) {
 		}
 
 		testee := kpggbg.New(pgpool)
-		pop, err := testee.Pop(ctx, func(g domain.Garbage) error {
-			if g == expectedGarbage {
-				return nil
-			}
-			return fmt.Errorf(
-				"argument of callback function does not match.(KnitId, VolumeRef= %v,%v)",
-				g.KnitId, g.VolumeRef)
-		})
-		//[Verification]
+		pop, err := testee.Pop(
+			ctx,
+			func(g domain.Garbage) error {
+				if g == expectedGarbage {
+					return nil
+				}
+				return fmt.Errorf(
+					"argument of callback function does not match.(KnitId, VolumeRef= %v,%v)",
+					g.KnitId, g.VolumeRef,
+				)
+			},
+		)
+		// [Verification]
 		// The record to be popped is passed as an argument to the callback function.
 		// The first return value "pop" of the target function is true, and the second return value is nil.
 		// The record count of the knit_id table and the garbage table becomes 0.
 		if !pop || err != nil {
 			t.Errorf(
 				"return value of test function does not match. (pop,err =%v,%v)",
-				pop, err)
+				pop, err,
+			)
 		}
 		var countKnitId int
 		var countGarbage int
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "knit_id";`).Scan(&countKnitId); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "knit_id";`,
+		).Scan(&countKnitId); err != nil {
 			t.Fatalf("counting record of knit_id is failed. %v", err)
 		}
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "garbage";`).Scan(&countGarbage); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "garbage";`,
+		).Scan(&countGarbage); err != nil {
 			t.Fatalf("counting record of gargabe is failed. %v", err)
 		}
 		if countKnitId != 0 || countGarbage != 0 {
 			t.Errorf(
 				"record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage)
+				countKnitId, countGarbage,
+			)
 		}
 	})
 
 	t.Run("If there is 1 record in garbage and the callback function is nil, that record will be popped", func(t *testing.T) {
-		//[Preparation]
-		//Connect to the database
-		//Insert 1 record into the knit_id table and the garbage table
+		// [Preparation]
+		// Connect to the database
+		// Insert 1 record into the knit_id table and the garbage table
 		ctx := context.Background()
 		pgpool := poolBroaker.GetPool(ctx, t)
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "knit_id" ("knit_id") values ('knit-1')`,
 		); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "garbage" ("knit_id","volume_ref") values ('knit-1','garbage-1')`,
 		); err != nil {
 			t.Fatal(err)
@@ -99,36 +113,44 @@ func TestGarbage_Pop(t *testing.T) {
 		// The first return value "pop" of the target function is true, and the second return value is nil.
 		// The record count of the "knit_id" table and the "garbage" table becomes 0.
 		if !pop || err != nil {
-			t.Errorf("return value of test function does not match. (pop,err =%v,%v)",
-				pop, err)
+			t.Errorf(
+				"return value of test function does not match. (pop,err =%v,%v)",
+				pop, err,
+			)
 		}
 		var countKnitId int
 		var countGarbage int
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "knit_id";`).Scan(&countKnitId); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "knit_id";`,
+		).Scan(&countKnitId); err != nil {
 			t.Fatalf("counting record of knit_id is failed. %v", err)
 		}
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "garbage";`).Scan(&countGarbage); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "garbage";`,
+		).Scan(&countGarbage); err != nil {
 			t.Fatalf("counting record of gargabe is failed. %v", err)
 		}
 		if countKnitId != 0 || countGarbage != 0 {
 			t.Errorf(
 				"record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage)
+				countKnitId, countGarbage,
+			)
 		}
 	})
 
 	t.Run("If there are 0 records in garbage, nothing is popped", func(t *testing.T) {
-		//[Preparation]
-		//Connect to the database
+		// [Preparation]
+		// Connect to the database
 		ctx := context.Background()
 		pgpool := poolBroaker.GetPool(ctx, t)
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
 
 		// Insert record into the knit_id table
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "knit_id" ("knit_id") values ('knit-1')`,
 		); err != nil {
 			t.Fatal(err)
@@ -136,15 +158,17 @@ func TestGarbage_Pop(t *testing.T) {
 
 		expectedError := fmt.Errorf("callback was used")
 		testee := kpggbg.New(pgpool)
-		pop, err := testee.Pop(ctx, func(domain.Garbage) error {
-			return expectedError
-		})
+		pop, err := testee.Pop(
+			ctx,
+			func(domain.Garbage) error { return expectedError },
+		)
 		//[Verification]
 		// The first return value "pop" of the target function is false, and the second return value is nil.
 		if pop || err != nil {
 			t.Errorf(
 				"return value of test function does not match. (pop,err) = (%v, %v)",
-				pop, err)
+				pop, err,
+			)
 		}
 		// The callback function is not executed.
 		if errors.Is(err, expectedError) {
@@ -168,22 +192,25 @@ func TestGarbage_Pop(t *testing.T) {
 		pgpool := poolBroaker.GetPool(ctx, t)
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "knit_id" ("knit_id") values ('knit-1')`,
 		); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "garbage" ("knit_id","volume_ref") values ('knit-1','garbage-1')`,
 		); err != nil {
 			t.Fatal(err)
 		}
 		expectedError := fmt.Errorf("callback causes expected error")
 		testee := kpggbg.New(pgpool)
-		pop, err := testee.Pop(ctx, func(domain.Garbage) error {
-			return expectedError
-		})
-		//[Verification]
+		pop, err := testee.Pop(
+			ctx,
+			func(domain.Garbage) error { return expectedError },
+		)
+		// [Verification]
 		// The first return value "pop" of the target function is false, and the second return value is expectedError.
 		if pop || !errors.Is(err, expectedError) {
 			t.Errorf(
@@ -193,35 +220,43 @@ func TestGarbage_Pop(t *testing.T) {
 		// The record count of the knit_id table and the garbage table remains unchanged (still 1).
 		var countKnitId int
 		var countGarbage int
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "knit_id";`).Scan(&countKnitId); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "knit_id";`,
+		).Scan(&countKnitId); err != nil {
 			t.Fatalf("counting record of knit_id is failed. %v", err)
 		}
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "garbage";`).Scan(&countGarbage); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "garbage";`,
+		).Scan(&countGarbage); err != nil {
 			t.Fatalf("counting record of gargabe is failed. %v", err)
 		}
 		if countKnitId != 1 || countGarbage != 1 {
-			t.Errorf("record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage)
+			t.Errorf(
+				"record count does not match. (countKnitId, countGarbage =%v,%v)",
+				countKnitId, countGarbage,
+			)
 		}
 	})
 	t.Run("If all records in the garbage table are locked, nothing is popped", func(t *testing.T) {
-		//[Preparation]
-		//Connect to the database
-		//Insert 1 record into the knit_id table and the garbage table
-		//Lock all records in the garbage table
+		// [Preparation]
+		// Connect to the database
+		// Insert 1 record into the knit_id table and the garbage table
+		// Lock all records in the garbage table
 		ctx := context.Background()
 		pgpool := poolBroaker.GetPool(ctx, t)
 		conn := try.To(pgpool.Acquire(ctx)).OrFatal(t)
 		defer conn.Release()
 
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "knit_id" ("knit_id") values ('knit-1')`,
 		); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := conn.Exec(ctx,
+		if _, err := conn.Exec(
+			ctx,
 			`insert into "garbage" ("knit_id","volume_ref") values ('knit-1','garbage-1')`,
 		); err != nil {
 			t.Fatal(err)
@@ -229,22 +264,26 @@ func TestGarbage_Pop(t *testing.T) {
 
 		locked := try.To(pgpool.Begin(ctx)).OrFatal(t)
 		defer locked.Rollback(ctx)
-		if _, err := locked.Exec(ctx,
-			`select * from "garbage" for update`); err != nil {
+		if _, err := locked.Exec(
+			ctx,
+			`select * from "garbage" for update`,
+		); err != nil {
 			t.Fatal(err)
 		}
 
 		expectedError := fmt.Errorf("callback was used")
 		testee := kpggbg.New(pgpool)
-		pop, err := testee.Pop(ctx, func(domain.Garbage) error {
-			return expectedError
-		})
-		//[Verification]
-		//The first return value of the test function should be false, and the second return value should be nil.
+		pop, err := testee.Pop(
+			ctx,
+			func(domain.Garbage) error { return expectedError },
+		)
+		// [Verification]
+		// The first return value of the test function should be false, and the second return value should be nil.
 		if pop || err != nil {
 			t.Errorf(
 				"return value of test function does not match. (pop,err) = (%v, %v)",
-				pop, err)
+				pop, err,
+			)
 		}
 		// The callback function is not executed
 		if errors.Is(err, expectedError) {
@@ -253,18 +292,23 @@ func TestGarbage_Pop(t *testing.T) {
 		// The record count of the knit_id table and the garbage table remains unchanged (still 1)
 		var countKnitId int
 		var countGarbage int
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "knit_id";`).Scan(&countKnitId); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "knit_id";`,
+		).Scan(&countKnitId); err != nil {
 			t.Fatalf("counting record of knit_id is failed. %v", err)
 		}
-		if err := conn.QueryRow(ctx,
-			`select count("knit_id") from "garbage";`).Scan(&countGarbage); err != nil {
+		if err := conn.QueryRow(
+			ctx,
+			`select count("knit_id") from "garbage";`,
+		).Scan(&countGarbage); err != nil {
 			t.Fatalf("counting record of gargabe is failed. %v", err)
 		}
 		if countKnitId != 1 || countGarbage != 1 {
 			t.Errorf(
 				"record count does not match. (countKnitId, countGarbage =%v,%v)",
-				countKnitId, countGarbage)
+				countKnitId, countGarbage,
+			)
 		}
 	})
 }

--- a/pkg/domain/internal/db/postgres/tables/assumption.go
+++ b/pkg/domain/internal/db/postgres/tables/assumption.go
@@ -2,12 +2,9 @@ package tables
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgerrcode"
 	kpool "github.com/opst/knitfab/pkg/conn/db/postgres/pool"
 	"github.com/opst/knitfab/pkg/domain"
 )
@@ -109,16 +106,31 @@ func (step *Step) apply(tbls *Tables) error {
 
 // Declare premise of test.
 type Operation struct {
-	Plan               []Plan
-	PlanEntrypoint     []PlanEntrypoint
-	PlanArgs           []PlanArgs
-	PlanResources      []PlanResource
-	OnNode             []PlanOnNode
-	PlanImage          []PlanImage
-	PlanPseudo         []PlanPseudo
-	Inputs             map[Input]InputAttr
-	Outputs            map[Output]OutputAttr
-	PlanAnnotations    []Annotation
+	// Orphan KnitId.
+	//
+	// When you put Gatbage or Outcomes in Steps, you do not need to put KnitId here.
+	KnitId []string
+
+	Plan []Plan
+
+	PlanEntrypoint []PlanEntrypoint
+
+	PlanArgs []PlanArgs
+
+	PlanResources []PlanResource
+
+	OnNode []PlanOnNode
+
+	PlanImage []PlanImage
+
+	PlanPseudo []PlanPseudo
+
+	Inputs map[Input]InputAttr
+
+	Outputs map[Output]OutputAttr
+
+	PlanAnnotations []Annotation
+
 	PlanServiceAccount []ServiceAccount
 
 	Steps []Step
@@ -146,6 +158,12 @@ func (prem *Operation) Apply(ctx context.Context, pool kpool.Pool) error {
 
 func (prem *Operation) ApplyWithConn(ctx context.Context, conn kpool.Queryer) error {
 	tbls := New(ctx, conn)
+
+	for _, kid := range prem.KnitId {
+		if err := tbls.InsertKnitId(kid); err != nil {
+			return err
+		}
+	}
 
 	for _, p := range prem.Plan {
 		if err := tbls.InsertPlan(&p); err != nil {
@@ -246,9 +264,7 @@ func (prem *Operation) ApplyWithConn(ctx context.Context, conn kpool.Queryer) er
 
 	for _, gab := range prem.Garbage {
 		if err := tbls.InsertKnitId(gab.KnitId); err != nil {
-			if pgerr := new(pgconn.PgError); !errors.As(err, &pgerr) || pgerr.Code != pgerrcode.UniqueViolation {
-				return err
-			}
+			return err
 		}
 		if err := tbls.InsertGarbage(&gab); err != nil {
 			return err

--- a/pkg/domain/internal/db/postgres/tables/assumption_test.go
+++ b/pkg/domain/internal/db/postgres/tables/assumption_test.go
@@ -22,6 +22,10 @@ import (
 func TestOperation(t *testing.T) {
 	poolBroaker := testenv.NewPoolBroaker(context.Background(), t)
 	testee := tables.Operation{
+		KnitId: []string{
+			th.Padding36("orphan-1"),
+			th.Padding36("orphan-2"),
+		},
 		Plan: []tables.Plan{
 			{PlanId: th.Padding36("plan-1"), Active: true, Hash: th.Padding64("#plan-1")},
 			{PlanId: th.Padding36("plan-2"), Active: false, Hash: th.Padding64("#plan-2")},
@@ -393,10 +397,34 @@ func TestOperation(t *testing.T) {
 	if err := testee.Apply(ctx, pool); err != nil {
 		t.Fatal(err)
 	}
+	conn := try.To(pool.Acquire(ctx)).OrFatal(t)
+	defer conn.Release()
+
+	t.Run("knitId", func(t *testing.T) {
+		actual := try.To(scanner.New[string]().QueryAll(
+			ctx, conn, `table "knit_id"`,
+		)).OrFatal(t)
+
+		expected := []string{
+			th.Padding36("orphan-1"),
+			th.Padding36("orphan-2"),
+			th.Padding36("data-1.run-1.plan-1"),
+			th.Padding36("data-1.run-2.plan-1"),
+			th.Padding36("data-1.run-1.plan-2"),
+			th.Padding36("data-1.run-1.plan-3"),
+			th.Padding36("data-2.run-1.plan-3"),
+			th.Padding36("data-3.run-1.plan-3"),
+			th.Padding36("log-1.run-1.plan-3"),
+			th.Padding36("data-x.run-x.plan-1"),
+			th.Padding36("data-y.run-x.plan-1"),
+		}
+
+		if !cmp.SliceContentEq(actual, expected) {
+			t.Errorf("unmatch:\n===actual===\n%+v\n===expected===\n%+v", actual, expected)
+		}
+	})
 
 	t.Run("plan", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
 		actual := try.To(scanner.New[tables.Plan]().QueryAll(
 			ctx, conn, `table "plan"`,
 		)).OrFatal(t)
@@ -409,9 +437,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("resources", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.PlanResource]().QueryAll(
 			ctx, conn, `table "plan_resource"`,
 		)).OrFatal(t)
@@ -423,8 +448,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("plan_on_node", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
 		actual := try.To(scanner.New[tables.PlanOnNode]().QueryAll(
 			ctx, conn, `table "plan_on_node"`,
 		)).OrFatal(t)
@@ -437,8 +460,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("plan_pseudo", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
 		actual := try.To(scanner.New[tables.PlanPseudo]().QueryAll(
 			ctx, conn, `table "plan_pseudo"`,
 		)).OrFatal(t)
@@ -451,8 +472,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("plan_image", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
 		actual := try.To(scanner.New[tables.PlanImage]().QueryAll(
 			ctx, conn, `table "plan_image"`,
 		)).OrFatal(t)
@@ -465,8 +484,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("plan_entrypoint", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
 		actual := try.To(scanner.New[tables.PlanEntrypoint]().QueryAll(
 			ctx, conn, `table "plan_entrypoint"`,
 		)).OrFatal(t)
@@ -478,8 +495,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("plan_args", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
 		actual := try.To(scanner.New[tables.PlanArgs]().QueryAll(
 			ctx, conn, `table "plan_args"`,
 		)).OrFatal(t)
@@ -491,8 +506,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("output", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
 		actual := try.To(scanner.New[tables.Output]().QueryAll(
 			ctx, conn, `table "output"`,
 		)).OrFatal(t)
@@ -505,9 +518,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("output tags", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		type tagOutput struct {
 			OutputId int
 			Key      string
@@ -543,9 +553,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("log", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		type log struct {
 			OutputId int
 			PlanId   string
@@ -570,9 +577,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("input", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.Input]().QueryAll(
 			ctx, conn, `table "input"`,
 		)).OrFatal(t)
@@ -585,9 +589,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("input tags", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		type tagInput struct {
 			InputId int
 			Key     string
@@ -623,9 +624,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("input knit#id", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		type knitIdInput struct {
 			InputId int
 			KnitId  string
@@ -651,9 +649,6 @@ func TestOperation(t *testing.T) {
 		}
 	})
 	t.Run("input knit#timestamp", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		type knitIdTimestamp struct {
 			InputId   int
 			Timestamp time.Time
@@ -685,9 +680,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("service account", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.ServiceAccount]().QueryAll(
 			ctx, conn, `table "plan_service_account"`,
 		)).OrFatal(t)
@@ -700,9 +692,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("plan_annotations", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.Annotation]().QueryAll(
 			ctx, conn, `table "plan_annotation"`,
 		)).OrFatal(t)
@@ -720,9 +709,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("run", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.Run]().QueryAll(
 			ctx, conn, `table "run"`,
 		)).OrFatal(t)
@@ -740,9 +726,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("assign", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.Assign]().QueryAll(
 			ctx, conn, `table "assign"`,
 		)).OrFatal(t)
@@ -760,9 +743,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("run exit", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.RunExit]().QueryAll(
 			ctx, conn, `table "run_exit"`,
 		)).OrFatal(t)
@@ -781,9 +761,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("data", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.Data]().QueryAll(
 			ctx, conn, `table "data"`,
 		)).OrFatal(t)
@@ -801,9 +778,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("data_tag", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		type tagData struct {
 			KnitId string
 			Key    string
@@ -846,9 +820,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("data_timestamp", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		type tagTimestamp struct {
 			KnitId    string
 			Timestamp time.Time
@@ -886,9 +857,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("data agent", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.DataAgent]().QueryAll(
 			ctx, conn, `table "data_agent"`,
 		)).OrFatal(t)
@@ -919,9 +887,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("nomination", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.Nomination]().QueryAll(
 			ctx, conn, `table "nomination"`,
 		)).OrFatal(t)
@@ -934,9 +899,6 @@ func TestOperation(t *testing.T) {
 	})
 
 	t.Run("garbage", func(t *testing.T) {
-		conn := try.To(pool.Acquire(ctx)).OrFatal(t)
-		defer conn.Release()
-
 		actual := try.To(scanner.New[tables.Garbage]().QueryAll(
 			ctx, conn, `table "garbage"`,
 		)).OrFatal(t)

--- a/pkg/domain/internal/db/postgres/tables/tables.go
+++ b/pkg/domain/internal/db/postgres/tables/tables.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
 
 	kpool "github.com/opst/knitfab/pkg/conn/db/postgres/pool"
 	"github.com/opst/knitfab/pkg/domain"
@@ -59,10 +60,15 @@ func shouldEffect(ctag pgconn.CommandTag, require int) error {
 func (f *Tables) InsertKnitId(knitId string) error {
 	ctag, err := f.conn.Exec(
 		f.ctx,
-		`insert into "knit_id" ("knit_id") values ($1)`,
+		`
+		insert into "knit_id" ("knit_id") values ($1)
+		`,
 		knitId,
 	)
 	if err != nil {
+		if pgerr, ok := err.(*pgconn.PgError); ok && pgerr.Code == pgerrcode.UniqueViolation {
+			return nil
+		}
 		return withCause(struct{ KnitId string }{KnitId: knitId}, err)
 	}
 	return shouldEffect(ctag, 1)


### PR DESCRIPTION
GC Loop deletes `knit_id` record only when it is not referenced by `data` records.