### PR TITLE
Response 410 for pulling purged Data

### DIFF
--- a/cmd/knitd_backend/handlers/data.go
+++ b/cmd/knitd_backend/handlers/data.go
@@ -146,6 +146,8 @@ func GetDataHandler(
 		if err != nil {
 			if errors.Is(err, kerr.ErrMissing) {
 				return binderr.NotFound()
+			} else if errors.Is(err, domain.ErrDataIsPurged) {
+				return binderr.Gone(binderr.WithError(err))
 			}
 			return binderr.InternalServerError(err)
 		}
@@ -153,6 +155,8 @@ func GetDataHandler(
 		dagt, err := iDataK8s.SpawnDataAgent(ctx, daRecord, deadline)
 		if errors.Is(err, k8serrors.ErrDeadlineExceeded) {
 			return binderr.ServiceUnavailable("please retry later", err)
+		} else if errors.Is(err, domain.ErrDataIsPurged) {
+			return binderr.Gone(binderr.WithError(err))
 		} else if err != nil {
 			return binderr.InternalServerError(err)
 		}

--- a/cmd/knitd_backend/handlers/data_test.go
+++ b/cmd/knitd_backend/handlers/data_test.go
@@ -240,6 +240,14 @@ func TestGetDataHandler(t *testing.T) {
 			errorFromSpawner:   k8serrors.ErrDeadlineExceeded,
 			expectedStatusCode: http.StatusServiceUnavailable,
 		},
+		"ErrDataIsPurged error causes 410 error (from NewAgent)": {
+			errorFromNewAgent:  domain.ErrDataIsPurged,
+			expectedStatusCode: http.StatusGone,
+		},
+		"ErrDataIsPurged error causes 410 error (from Spawner)": {
+			errorFromSpawner:   domain.ErrDataIsPurged,
+			expectedStatusCode: http.StatusGone,
+		},
 		"other errors causes 500 error": {
 			errorFromSpawner:   errors.New("fake error"),
 			expectedStatusCode: http.StatusInternalServerError,

--- a/pkg/api-types-binding/errors/error.go
+++ b/pkg/api-types-binding/errors/error.go
@@ -89,8 +89,20 @@ func ServiceUnavailable(advice string, err error) *echo.HTTPError {
 	)
 }
 
-func NotFound() *echo.HTTPError {
-	return NewErrorMessage(http.StatusNotFound, "not found")
+func NotFound(options ...ErrorMessageOption) *echo.HTTPError {
+	return NewErrorMessage(
+		http.StatusNotFound,
+		"not found",
+		options...,
+	)
+}
+
+func Gone(options ...ErrorMessageOption) *echo.HTTPError {
+	return NewErrorMessage(
+		http.StatusGone,
+		"This resource is not available anymore",
+		options...,
+	)
 }
 
 func BadRequest(advice string, err error) *echo.HTTPError {

--- a/pkg/domain/data.go
+++ b/pkg/domain/data.go
@@ -10,6 +10,7 @@ import (
 
 var ErrUnknownDataAgentMode = errors.New("unknown data agent mode")
 var ErrDataInUse = errors.New("data is in use")
+var ErrDataIsPurged = errors.New("data is purged")
 
 type DataAgentMode string
 

--- a/pkg/domain/data/db/data.go
+++ b/pkg/domain/data/db/data.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -142,8 +141,6 @@ type DataInterface interface {
 	Purge(ctx context.Context, knitId string) error
 }
 
-var ErrDataIsPurged = errors.New("Data is purged")
-
 func NewErrDataIsPurged(knitId string) error {
-	return fmt.Errorf("%w: %s", ErrDataIsPurged, knitId)
+	return fmt.Errorf("%w: %s", domain.ErrDataIsPurged, knitId)
 }

--- a/pkg/domain/data/db/postgres/tests/new_agent_test/new_agent_test.go
+++ b/pkg/domain/data/db/postgres/tests/new_agent_test/new_agent_test.go
@@ -12,7 +12,6 @@ import (
 	testenv "github.com/opst/knitfab/pkg/conn/db/postgres/pool/testenv"
 	"github.com/opst/knitfab/pkg/conn/db/postgres/scanner"
 	"github.com/opst/knitfab/pkg/domain"
-	kdbdata "github.com/opst/knitfab/pkg/domain/data/db"
 	kpgdata "github.com/opst/knitfab/pkg/domain/data/db/postgres"
 	kerr "github.com/opst/knitfab/pkg/domain/errors"
 	"github.com/opst/knitfab/pkg/domain/internal/db/postgres/tables"
@@ -205,7 +204,7 @@ func TestNewAgent(t *testing.T) {
 		testee := kpgdata.New(pool)
 
 		_, err := testee.NewAgent(ctx, knitIdPurged, domain.DataAgentRead, 30*time.Second)
-		if !errors.Is(err, kdbdata.ErrDataIsPurged) {
+		if !errors.Is(err, domain.ErrDataIsPurged) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})

--- a/pkg/domain/data/k8s/data/metasource.go
+++ b/pkg/domain/data/k8s/data/metasource.go
@@ -43,7 +43,7 @@ func Of(d domain.KnitDataBody) (Builder, error) {
 		)
 	}
 	if d.VolumeRef == nil {
-		return nil, fmt.Errorf("Data is purged: knit#id = %s", d.KnitId)
+		return nil, fmt.Errorf("%w: knit#id = %s", domain.ErrDataIsPurged, d.KnitId)
 	}
 	return Data{
 		KnitId:    d.KnitId,


### PR DESCRIPTION
API `GET /api/data/:knitId` responses 410 when the target Data is purged.

## Related Issues

- closes #306 