### PR TITLE
`./testctl.sh` uses its dedicated colima profile

### DIFF
--- a/testctl.sh
+++ b/testctl.sh
@@ -7,33 +7,38 @@ MINIKUBE=${MINIKUBE:-minikube}
 COLIMA=${COLIMA:-colima}
 
 KUBECONFIG=${KUBECONFIG:-${HOME}/.kube/config}
-KNIT_TEST_KUBECONFIG=${KNIT_TEST_KUBECONFIG:-${KUBECONFIG}}
-KNIT_TEST_KUBECTX=${KNIT_TEST_KUBECTX}
-KNIT_TEST_NAMESPACE=${NAMESPACE:-knit-test}
 
 cd ${0%/*}
+if [ -r ./testenv ] ; then
+	source ./testenv
+fi
+
+KNIT_TEST_KUBECONFIG=${KNIT_TEST_KUBECONFIG:-${KUBECONFIG}}
+KNIT_TEST_COLIMA_PROFILE=${KNIT_TEST_COLIMA_PROFILE:-knit-test}
+KNIT_TEST_KUBECTX=${KNIT_TEST_KUBECTX:-colima-${KNIT_TEST_COLIMA_PROFILE}}
+KNIT_TEST_NAMESPACE=${NAMESPACE:-knit-test}
+
+BASE_KUBECONTEXT=${BASE_KUBECONTEXT:-$(kubectl --kubeconfig ${KNIT_TEST_KUBECONFIG} config current-context)}
+trap "kubectl config use-context ${BASE_KUBECONTEXT}" EXIT
 
 # start up k8s and write envvars for docker
 function up() {
 	case ${1} in
 		colima|*)  # default
-			if ! colima status 2> /dev/null ; then
-				${COLIMA} start --kubernetes
+			if ! colima status -p ${KNIT_TEST_COLIMA_PROFILE} 2> /dev/null ; then
+				${COLIMA} start -p ${KNIT_TEST_COLIMA_PROFILE} --kubernetes
 			fi
 		;;
 	esac
 }
 # echo "no kubeconfig supplied. use minikube (with command '${MINIKUBE}') ." >&2
 
-HELMOPTS="--kubeconfig ${KNIT_TEST_KUBECONFIG}"
-KUBEOPTS="--kubeconfig ${KNIT_TEST_KUBECONFIG}"
+HELMOPTS="--kubeconfig ${KNIT_TEST_KUBECONFIG} --kube-context ${KNIT_TEST_KUBECTX}"
+KUBEOPTS="--kubeconfig ${KNIT_TEST_KUBECONFIG} --context ${KNIT_TEST_KUBECTX}"
 
 case ${1} in
 	install)
 		up ${2}
-		KNIT_TEST_KUBECTX=$(${KUBECTL} ${KUBEOPTS} config current-context)
-		HELMOPTS="${HELMOPTS} --kube-context ${KNIT_TEST_KUBECTX}"
-		KUBEOPTS="${KUBEOPTS} --context ${KNIT_TEST_KUBECTX}"
 		APP_VERSION=TEST CHART_VERSION=v0.0.0 ARCH=test ./build/build.sh --test image chart
 		echo "" >&2
 
@@ -72,12 +77,14 @@ case ${1} in
 		echo "# Knit test environment. Generated with testctl.sh" > ./.testenv
 		echo "" >> ./.testenv
 		echo "KNIT_TEST_KUBECONFIG=${KNIT_TEST_KUBECONFIG}" | tee -a ./.testenv >&2
+		echo "KNIT_TEST_COIIMA_PROFILE=${KNIT_TEST_COLIMA_PROFILE}" | tee -a ./.testenv >&2
 		echo "KNIT_TEST_KUBECTX=${KNIT_TEST_KUBECTX}"       | tee -a ./.testenv >&2
 		echo "KNIT_TEST_NAMESPACE=${KNIT_TEST_NAMESPACE}"   | tee -a ./.testenv >&2
 		echo "---------" >&2
 		echo "(these configs are written in \"$(pwd)/.testenv\" .)" >&2
 		;;
 	uninstall)
+		up ${2}
 		${HELM} ${HELMOPTS} uninstall --namespace ${KNIT_TEST_NAMESPACE} --wait knit-test || :
 		${HELM} ${HELMOPTS} uninstall --namespace ${KNIT_TEST_NAMESPACE} --wait knit-schema-upgrader || :
 		${HELM} ${HELMOPTS} uninstall --namespace ${KNIT_TEST_NAMESPACE} --wait knit-db-postgres || :
@@ -87,12 +94,10 @@ case ${1} in
 		;;
 	test)
 		shift || :
-		if [ -r ./.testenv ] ; then
-			. ./.testenv
-			export KNIT_TEST_KUBECONFIG
-			export KNIT_TEST_KUBECTX
-			export KNIT_TEST_NAMESPACE
-		fi
+		up ${2}
+		export KNIT_TEST_KUBECONFIG
+		export KNIT_TEST_KUBECTX
+		export KNIT_TEST_NAMESPACE
 
 		echo "# (root)" >&2
 		go test -p=1 $@ ./...
@@ -103,6 +108,12 @@ case ${1} in
 				go test -p=1 $@ ./...
 			)
 		done
+		;;
+	delete)
+		${COLIMA} -p ${KNIT_TEST_COLIMA_PROFILE} delete
+		;;
+	stop)
+		${COLIMA} -p ${KNIT_TEST_COLIMA_PROFILE} stop
 		;;
 	*)
 		echo "unknown command '${1}'. should be one of: cni, install, upgrade, uninstall, test" >&2


### PR DESCRIPTION
To isolate test environment from developer's default environment, `./testctl.sh` uses dedicated colima profile.

##  Related Issues

- closes #322
