### PR TITLE
Feature/#339/rootless dev cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ This command does...
 - Provision Kubernetes Cluster (with minikube) of 3 VMs (with qemu driver) as profile named "knitfab-dev-cluster"
 - Deploy Image Registry (at `:30005` on each nodes).
     - This Image Registry is *not a part of Knitfab*. Knitfab emploies anothor Registry for itself.
-- Put self-signed CA certification at `./dev-cluster/docker-certs/meta` and `~/.docker/certs.d/${node ip}:30005/ca.crt`.
-    - You may need to copy the certification to `/etc/docker/certs.d/${node ip}:30005/ca.crt` on your dockerd.
+- Put self-signed CA certification at `./dev-cluster/docker-certs/meta` and `~/.docker/certs.d/${YOUR-IP}:30005/ca.crt`.
+    - You may need to copy the certification to `/etc/docker/certs.d/${YOUR-IP}:30005/ca.crt` on your dockerd.
 
 It takes 5+ minutes at least. Please be patient.
 If you want to throw away them all, just do `./dev-cluster/destroy.sh` and the VMs and k8s clusters will be destroyed.
@@ -254,13 +254,12 @@ kubectl --context knitfab-dev-cluster ...
 
 ### Install Knitfab into the dev-cluster
 
-1. Copy `./dev-cluster/docker-certs/meta/ca.crt` to your `/etc/docker/certs.d/${node-ip}:30005`
-    - To know minikube node IP, `minikube -p knitfab-dev-cluster ip`.
-    - You needs this operation only when on newly creating your dev-cluster.
+1. Copy `./dev-cluster/docker-certs/meta/ca.crt` to your `/etc/docker/certs.d/${YOUR-IP}:30005`
+    - Hereby, `${YOUR-IP}` should NOT be loopback address nor `localhost`.
 2. Then run `./dev-cluster/install-knit.sh --prepare` (once)
 3. Edit install setting directory (once)
 4. Import CA certification to your docker (once)
-    - Copy `./dev-cluster/knitfab-install-settings/docker/certs.d/${node ip}:${PORT}/ca.crt` to `/etc/docker/certs.d/${node ip}:${PORT}/ca.crt`
+    - Copy `./dev-cluster/knitfab-install-settings/docker/certs.d/${YOUR-IP}:${PORT}/ca.crt` to `/etc/docker/certs.d/${YOUR-IP}:${PORT}/ca.crt`
 5. Then run `./dev-cluster/install-knit.sh`
 
 In step 2, it generates an install setting directory as `./dev-cluster/knitfab-install-settings`.
@@ -280,6 +279,8 @@ nfs:
   # ...
 ```
 
+In step 2, `./dev-cluster/install-knit.sh` perform port-forward to 
+
 For more anothor config, consult `docs/03.admin-guide`.
 
 > **Note**
@@ -290,6 +291,16 @@ For more anothor config, consult `docs/03.admin-guide`.
 > For example, in the case of colima, `ca.crt` should place `/etc/docker/certs.d/...` *IN COLIMA*.
 > You may need to `colima ssh` and copy the file.
 >
+
+#### Port Forwarding
+
+`minikube` cluster of dev-cluster cannot be reached from host machine directly.
+To use `knit` command or push images to in-cluster repository, port-forwarding is needed.
+
+`./dev-cluster/connect` does port-forwarding.
+
+Knitfab API is exposed at `${YOUR-IPADDR}:30803` and image registry is exposed at `${YOUR-IPADDR}:30503`.
+For detail, read log of `./dev-cluster/connect`.
 
 #### `./dev-cluster/knitctl.sh`
 

--- a/dev-cluster/connect
+++ b/dev-cluster/connect
@@ -1,0 +1,26 @@
+#! /bin/bash
+set -e
+
+HERE=$(cd ${0%/*}; pwd)
+
+NAMESPACE=$(cat "${HERE}/knitfab-install-settings/namespace")
+KUBECONTEXT=$(cat "${HERE}/knitfab-install-settings/kubecontext")
+export KUBECONFIG="${HERE}/knitfab-install-settings/kubeconfig"
+
+. ${HERE}/knitfab-install-settings/domains
+
+for NAME in ${TLS_CERT_DOMAIN} ${TLS_CERT_IP} ; do
+    KNITFAB_HOST=${NAME}
+    break
+done
+
+echo "start port-forwarding"
+kubectl --context ${KUBECONTEXT} -n ${NAMESPACE} port-forward --address ${KNITFAB_HOST} service/knitd 30803:8080 &
+PID_PORTFWD_API=$!
+trap "kill ${PID_PORTFWD_API}; echo stop port-forwarding" EXIT
+
+kubectl --context ${KUBECONTEXT} -n ${NAMESPACE} port-forward --address ${KNITFAB_HOST} service/image-registry 30503:80 &
+PID_PORTFWD_REGISTRY=$!
+trap "kill ${PID_PORTFWD_REGISTRY} ${PID_PORTFWD_API}; echo stop port-forwarding" EXIT
+
+wait

--- a/dev-cluster/install-knit.sh
+++ b/dev-cluster/install-knit.sh
@@ -31,16 +31,36 @@ while [ -n "${1}" ] ; do
 	esac
 done
 
+# detect IP addr of this machine
+if [ -z "${IP}" ] ; then
+  if which ip > /dev/null 2>&1 ; then
+    IP=$(ip -4 addr show | grep -E 'inet (10|192|172)' | awk '{print $2}' | cut -d/ -f1 | head -n 1)
+  elif which ifconfig > /dev/null 2>&1 ; then
+    IP=$(ifconfig | grep -E 'inet (10|192|172)' | awk '{print $2}' | head -n 1)
+  else 
+    echo "Cannot find IP address of this machine. Please set IP manually."
+    exit 1
+  fi
+fi
+
 if [ -n "${PREPARE}" ] ; then
-	${ROOT}/installer/installer.sh --prepare -s ${HERE}/knitfab-install-settings ${ARGS}
+	${ROOT}/installer/installer.sh --prepare -s ${HERE}/knitfab-install-settings --tls-cert-ip ${IP} ${ARGS}
 	exit
 fi
 
+
 if [ -n "${BUILD}" ] ; then
 	${ROOT}/build/build.sh
-	NODE_IP=$(minikube -p ${KUBECONTEXT} ip)
-	IMAGE_REGISTRY="${NODE_IP}:30005" bash ${ROOT}/bin/images/local/publish.sh
-	# portnumber comes from ./lib/install-registry.sh.
+	
+	(
+		echo "start port-forwarding"
+		kubectl --context ${KUBECONTEXT} -n registry port-forward --address ${IP} service/image 30005:5000 > /dev/null &
+		PID_PORTFWD=$!
+		trap "kill ${PID_PORTFWD}; echo stop port-forwarding" EXIT
+		sleep 5
+		IMAGE_REGISTRY="${IP}:30005" bash ${ROOT}/bin/images/local/publish.sh
+		# portnumber comes from ./lib/install-registry.sh.
+	)
 fi
 
 export CHART_VERSION=$(cat ${ROOT}/charts/local/CHART_VERSION)

--- a/dev-cluster/kurl
+++ b/dev-cluster/kurl
@@ -1,7 +1,24 @@
 #! /bin/bash
 
 HERE=${0%/*}
-KNIT_HOST=${KNIT_HOST:-10.10.0.3:30803}
+
+if [ -z ${KNIT_HOST} ] ; then
+	if [ -r ${HERE}/knitfab-install-settings/domains ] ; then
+		. ${HERE}/knitfab-install-settings/domains
+		for D in ${TLS_CERT_IP} ; do
+			KNIT_HOST=${D}
+			break
+		done
+		for D in ${TLS_CERT_DOMAIN} ; do
+			KNIT_HOST=${D}
+			break
+		done
+	fi
+fi
+
+if [ -z ${KNIT_HOST} ] ; then
+	echo "KNIT_HOST is not set!" >&2
+fi
 
 DEFAULT_CACERT=${HERE}/knitfab-install-settings/certs/ca.crt
 CACERT=${CACERT:-${DEFAULT_CACERT}}
@@ -10,7 +27,7 @@ declare -a ARG
 for V in "$@" ; do
 	case "$V" in
 		knit://*)
-			ARG[${#ARG[@]}]="https://${KNIT_HOST}/${V:7}"
+			ARG[${#ARG[@]}]="https://${KNIT_HOST}:30803/${V:7}"
 			;;
 		-h|--help)
 cat <<EOF

--- a/dev-cluster/lib/new-tlscerts.sh
+++ b/dev-cluster/lib/new-tlscerts.sh
@@ -21,9 +21,15 @@ function get_node_ip() {
 function alt_names() {
     COUNT=0
     if [ -n "${USE_NODE_IPS}" ] ; then
-        for IP in $(get_node_ip) ; do
+        for I in $(get_node_ip) ; do
             COUNT=$((COUNT + 1))
-            echo "IP.${COUNT}=${IP}"
+            echo "IP.${COUNT}=${I}"
+        done
+    fi
+    if [ -n "${IP}" ] ; then
+        for I in ${IP} ; do
+            COUNT=$((COUNT + 1))
+            echo "IP.${COUNT}=${I}"
         done
     fi
     for N in ${NAME} ; do
@@ -43,6 +49,9 @@ while [ ${#} -gt 0 ] ; do
             ;;
         --no-node-ips)
             USE_NODE_IPS=
+            ;;
+        --ip)
+            IP="${IP} ${1}"; shift
             ;;
         --name)
             NAME="${NAME} ${1}"; shift

--- a/dev-cluster/lib/nfs-service.kube.yaml
+++ b/dev-cluster/lib/nfs-service.kube.yaml
@@ -30,13 +30,39 @@ spec:
       labels:
         app: nfs-server
     spec:
+      initContainers:
+        - name: init-recovery-dir
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args: ["mkdir -p /var/lib/nfs/ganesha/v4_recovery/node0"]
+          volumeMounts:
+            - name: nfs-recovery
+              mountPath: /var/lib/nfs/ganesha/v4_recovery
+        # - name: init-shared-dir
+        #   image: busybox
+        #   command: ["/bin/sh", "-c"]
+        #   args: ["touch /export/ganesha"]
+        #   volumeMounts:
+        #     - name: nfs-data-ganesha
+        #       mountPath: /export
       containers:
         - name: nfs-server
-          image: itsthenetwork/nfs-server-alpine:latest
+          image: hectorm/nfs-ganesha:v9
+          # command:
+          #   - sleep
+          # args:
+          #   - "30000000"
           securityContext:
-            privileged: true
             capabilities:
-              add: ["SYS_ADMIN", "SETPCAP"]
+              add: 
+                - "SYS_RESOURCE"
+                - "CHOWN"
+                - "DAC_OVERRIDE"
+                - "DAC_READ_SEARCH"
+                - "FOWNER"
+                - "FSETID"
+                - "SETGID"
+                - "SETUID"
           ports:
             - containerPort: 2049
               protocol: TCP
@@ -45,32 +71,32 @@ spec:
             - containerPort: 111
               protocol: UDP
           volumeMounts:
+            - name: nfs-data-ganesha
+              mountPath: /var/lib/nfs/ganesha/export
             - name: nfs-data
-              mountPath: /nfsshare
-          env:
-            - name: SHARED_DIRECTORY
-              value: /nfsshare
-            - name: NFS_VERSION
-              value: "4"
-            - name: RPCMOUNTD_PORT
-              value: "111"
-            - name: RPCNFSDCOUNT
-              value: "8"
-            - name: RPCNFSDPRIORITY
-              value: "0"
-            - name: MOUNTD_PORT
-              value: "111"
-            - name: NFS_PORT
-              value: "2049"
-            - name: LOCKD_TCPPORT
-              value: "32803"
-            - name: LOCKD_UDPPORT
-              value: "32803"
+              mountPath: /export
+            - name: nfs-recovery
+              mountPath: /var/lib/nfs/ganesha/v4_recovery
+            - name: config
+              mountPath: /etc/ganesha/
+            - name: mtab
+              mountPath: /etc/mtab
       volumes:
+        - name: nfs-data-ganesha
+          emptyDir: {}
         - name: nfs-data
           hostPath:
-            path: /exports
+            path: /data/export
             type: DirectoryOrCreate
+        - name: nfs-recovery
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: nfs-server-config
+        - name: mtab
+          hostPath:
+            path: /proc/self/mounts
+            type: File
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -80,6 +106,53 @@ spec:
                     operator: In
                     values:
                       - knitfab-dev-cluster
+
+---
+# configmap overridding entrypoint
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfs-server-config
+  namespace: knitfab-dev-cluster-infra
+  labels:
+    app: nfs-server
+data:
+  ganesha.conf: |
+    NFS_Core_Param {
+      NFS_Port = 2049;
+      Protocols = 4;
+      Fsid_Device = true;
+      mount_path_pseudo = true;
+    }
+
+    NFSv4 {
+      RecoveryBackend = fs_ng;
+      RecoveryDir = v4_recovery;
+      Lease_Lifetime = 40;
+      Grace_Period = 50;
+      Only_Numeric_Owners = true;
+    }
+
+    VFS {}
+
+    EXPORT {
+      Export_id = 1;
+      Path = /export;
+      Pseudo = /;
+
+      Access_Type = RW;
+      Squash = noidsquash;
+      SecType = sys;
+      Protocols = 4;
+
+      FSAL {
+        Name = "vfs";
+      }
+    }
+
+    LOG {
+      Default_Log_Level = INFO;
+    }
 
 ---
 ## Service

--- a/dev-cluster/up.sh
+++ b/dev-cluster/up.sh
@@ -17,7 +17,7 @@ if ! minikube status -p knitfab-dev-cluster | grep -q "Running" ; then
   if [ -n "${BASE_KUBECONTEXT}" ] ; then
     trap "echo reset k8s context...; kubectl config use-context ${BASE_KUBECONTEXT}" EXIT
   fi
-  minikube start -p knitfab-dev-cluster --nodes 3 --driver=qemu --container-runtime=containerd --memory=6g --cpus=2
+  minikube start -p knitfab-dev-cluster --nodes 1 --driver=qemu --container-runtime=containerd --memory=6g --cpus=2
   echo $(kubectl config current-context) > "${HERE}/.dev-cluster-kube-context"
 fi
 
@@ -36,18 +36,45 @@ export TLSKEY="${HERE}/docker-certs/meta/server.key"
 export TLSCACERT="${HERE}/docker-certs/meta/ca.crt"
 export TLSCAKEY="${HERE}/docker-certs/meta/ca.key"
 
+# detect IP addr of this machine
+if [ -z "${IP}" ] ; then
+  if which ip > /dev/null 2>&1 ; then
+    IP=$(ip -4 addr show | grep -E 'inet (10|192|172)' | awk '{print $2}' | cut -d/ -f1)
+  elif which ifconfig > /dev/null 2>&1 ; then
+    IP=$(ifconfig | grep -E 'inet (10|192|172)' | awk '{print $2}')
+  else 
+    echo "Cannot find IP address of this machine. Please set IP manually."
+    exit 1
+  fi
+fi
+
 if [ -f ${TLSCERT} ] && [ -f ${TLSKEY} ] ; then
 	echo "TLS certificate and key already exist"
 else
-	"${HERE}/lib/new-tlscerts.sh" --dest "${HERE}/docker-certs/meta" --node-ips
+  IPS=
+  for I in ${IP} ; do
+    IPS="${IPS} --ip ${I}"
+  done
+	"${HERE}/lib/new-tlscerts.sh" --dest "${HERE}/docker-certs/meta" --node-ips ${IPS} --name localhost
 fi
 
-
 NODE_IP=$(minikube -p knitfab-dev-cluster ip)
-CERTS_DIR="${HOME}/.docker/certs.d/${NODE_IP}:30005"
-echo "Importing TLS CA certificate into ${CERTS_DIR}" >&2
-mkdir -p "${CERTS_DIR}"
-cp ${TLSCACERT} ${CERTS_DIR}/ca.crt
+CERTS_DIR_MINIKUBE="${HOME}/.docker/certs.d/${NODE_IP}:30005"
+echo "Importing TLS CA certificate into ${CERTS_DIR_MINIKUBE}" >&2
+mkdir -p "${CERTS_DIR_MINIKUBE}"
+cp ${TLSCACERT} ${CERTS_DIR_MINIKUBE}/ca.crt
+echo  "This directory is created by knitfab-dev-cluser at $(date)" > "${CERTS_DIR_MINIKUBE}/knitfab-dev-cluster"
+
+for I in ${IP} ; do
+  if [ "${I}" != "${NODE_IP}" ] ; then
+    D="${HOME}/.docker/certs.d/${I}:30005"
+    CERTS_DIR_LOCAL="${CERTS_DIR_LOCAL:+,}${D}"
+    echo "Importing TLS CA certificate into ${D}" >&2
+    mkdir -p "${D}"
+    cp ${TLSCACERT} ${D}/ca.crt
+    echo  "This directory is created by knitfab-dev-cluser at $(date)" > "${D}/knitfab-dev-cluster"
+  fi
+done
 
 "${HERE}/lib/install-registry.sh"
 
@@ -70,7 +97,8 @@ You can access the cluster using the following command:
 
 # TLS certificate and key for the image registry are located in:
 
-    ${CERTS_DIR}/ca.crt
+    \{${CERTS_DIR_LOCAL}\}/ca.crt and
+    ${CERTS_DIR_MINIKUBE}/ca.crt
 
 (You may need to restart your dockerd to pick up the new certificate.)
 

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -354,9 +354,25 @@ function renew_certs() {
 			message "(Server certificate copied from ${TLS_CERT})"
 		else
 
-			function alt_names() {
-				local DNS=()
+			if [ -z "${TLS_CERT_IP}" ] ; then
 				for NAME in $(get_node_ip) ; do
+					TLS_CERT_IP="${TLS_CERT_IP} ${NAME}"
+				done
+			fi
+
+			if [ -n "${TLS_CERT_DOMAIN}" ] ; then
+				echo "TLS_CERT_DOMAIN=\"${TLS_CERT_DOMAIN}\"" >> ${SETTINGS}/domains
+			fi
+			if [ -n "${TLS_CERT_IP}" ] ; then
+				echo "TLS_CERT_IP=\"${TLS_CERT_IP}\"" >> ${SETTINGS}/domains
+			fi
+
+			function alt_names() {
+				for NAME in ${TLS_CERT_DOMAIN} ; do
+					COUNT=$((COUNT + 1))
+					echo "DNS.${COUNT} = ${NAME}"
+				done
+				for NAME in ${TLS_CERT_IP} ; do
 					COUNT=$((COUNT + 1))
 					echo "IP.${COUNT} = ${NAME}"
 				done
@@ -451,32 +467,49 @@ This directory contains resources to connect your knitfab.
     - for more detail, see https://docs.docker.com/engine/security/certificates/
 EOF
 
-	for IP in $(get_node_ip) ; do
-		if [ -f "${SETTINGS}/certs/ca.crt" ] ; then
-			cat <<EOF > "${SETTINGS}/handouts/knitprofile"
+	KNITFAB_ORIGIN=
+	if [ -f "${SETTINGS}/certs/ca.crt" ] ; then
+		SCHEMA="https://"
+	else
+		SCHEMA="http://"
+	fi
+
+	KNITFAB_HOST=
+	if [ -r ${SETTINGS}/domains ] ; then
+		. ${SETTINGS}/domains
+		
+		for NAME in ${TLS_CERT_DOMAIN} ${TLS_CERT_IP} ; do
+			KNITFAB_HOST="${NAME}"
+			break
+			# pick first one
+		done
+		if [ -z "${KNITFAB_HOST}" ] ; then
+			echo "ERROR: no domain name found in ${SETTINGS}/domains" >&2
+			exit 1
+		fi
+	else
+		for NAME in $(get_node_ip) ; do
+			KNITFAB_HOST="${NAME}"
+			break
+			# pick first one
+		done
+	fi
+
+	KNITFAB_ORIGIN="${SCHEMA}${KNITFAB_HOST}:$(${KUBECTL} --context ${KUBECONTEXT} -n ${NAMESPACE} get service/knitd -o jsonpath="{.spec.ports[?(@.name==\"knitd\")].nodePort}")"
+
+	cat <<EOF > "${SETTINGS}/handouts/knitprofile"
 # knit profile file
 # pass this file to your knit client in your project directory: \`knit init knitprofile\`
-apiRoot: https://${IP}:$(${KUBECTL} --context ${KUBECONTEXT} -n ${NAMESPACE} get service/knitd -o jsonpath="{.spec.ports[?(@.name==\"knitd\")].nodePort}")/api
+apiRoot: ${KNITFAB_ORIGIN}/api
 cert:
   ca: $(cat "${SETTINGS}/certs/ca.crt" | base64 | tr -d '\r\n')
 EOF
-		else
-			cat <<EOF > "${SETTINGS}/handouts/knitprofile"
-# knit profile file
-# pass this file to your knit client in your project directory: \`knit init knitprofile\`
-apiRoot: http://${IP}:$(${KUBECTL} --context ${KUBECONTEXT} -n ${NAMESPACE} get service/knitd -o jsonpath="{.spec.ports[?(@.name==\"knitd\")].nodePort}")/api
-cert: {}
-EOF
-		fi
 
-		DOCKER_CERT_D="${SETTINGS}/handouts/docker/certs.d/${IP}:"$(${KUBECTL} --context ${KUBECONTEXT} -n ${NAMESPACE} get service/image-registry -o jsonpath="{.spec.ports[?(@.name==\"image-registry\")].nodePort}")
-		mkdir -p "${DOCKER_CERT_D}"
-		if [ -f "${SETTINGS}/certs/ca.crt" ] ; then
-			cp "${SETTINGS}/certs/ca.crt" "${DOCKER_CERT_D}/ca.crt"
-		fi
-
-		break  # pick one IP
-	done
+	DOCKER_CERT_D="${SETTINGS}/handouts/docker/certs.d/${KNITFAB_HOST}:"$(${KUBECTL} --context ${KUBECONTEXT} -n ${NAMESPACE} get service/image-registry -o jsonpath="{.spec.ports[?(@.name==\"image-registry\")].nodePort}")
+	mkdir -p "${DOCKER_CERT_D}"
+	if [ -f "${SETTINGS}/certs/ca.crt" ] ; then
+		cp "${SETTINGS}/certs/ca.crt" "${DOCKER_CERT_D}/ca.crt"
+	fi
 }
 
 function install() {
@@ -694,6 +727,12 @@ while [ 0 -lt ${#} ] ; do
 		--tls-key)
 			TLS_KEY=${1}; shift || :
 			;;
+		--tls-cert-domain)
+			TLS_CERT_DOMAIN="${TLS_CERT_DOMAIN} ${1}"; shift || :
+			;;
+		--tls-cert-ip)
+			TLS_CERT_IP="${TLS_CERT_IP} ${1}"; shift || :
+			;;
 		# Renew Self-signed CA Certificates
 		# This works only with --renew-certs.
 		--renew-ca)
@@ -745,7 +784,15 @@ ${THIS} --prepare \\
 * --tls-ca-cert and --tls-ca-key are the CA certificate and key for the Knitfab.
   Optional. If missing, it generates self-signed CA certificate & key.
 * --tls-cert and --tls-key are the server certificate and key for the Knitfab.
-  Optional. If missing, it generates certificate & key by CA.
+  Optional. If missing, it generates certificate & key by CA and certify --tls-cert-ip values.
+* --tls-cert-ip is the IP address of the server certificate.
+  Optional. This value is used in the additional SAN field of the server certificate.
+  You can set multiple IP addresses by repeating this option.
+  By default, it uses the IP address of the nodes.
+* --tls-cert-domain is the domain name of the server certificate.
+  Optional. This value is used in the additional SAN field of the server certificate.
+  You can set multiple domains by repeating this option.
+  This value is effective only when \`--tls-cert\` is not set.
 * --no-tls is a flag to skip (and remove) generating TLS certificates.
   Optional. If set, other TLS related flags are ignored.
 * --settings is the directory where install settings are saved.
@@ -797,7 +844,9 @@ ${THIS} --renew-certs \\
     [--renew-ca] \\
 	[--no-tls] \\
     [--tls-ca-cert <CA_CERT>] [--tls-ca-key <CA_KEY>] \\
-    [--tls-cert <TLS_CERT>] [--tls-key <TLS_KEY>]
+    [--tls-cert <TLS_CERT>] [--tls-key <TLS_KEY>] \\
+	[--tls-cert-domain <DOMAIN> [--tls-cert-domain ...]] \\
+	[--tls-cert-ip <IP> [--tls-cert-ip ...]]
 \`\`\`
 
 This mode renews TLS (server) certificates.
@@ -807,7 +856,15 @@ This mode renews TLS (server) certificates.
 * --tls-ca-cert and --tls-ca-key are the CA certificate and key for the Knitfab.
   Optional. If missing, it generates self-signed CA certificate & key.
 * --tls-cert and --tls-key are the server certificate and key for the Knitfab.
-  Optional. If missing, it generates certificate & key by CA.
+  Optional. If missing, it generates certificate & key by CA and certify --tls-cert-ip values.
+* --tls-cert-ip is the IP address of the server certificate.
+  Optional. This value is used in the additional SAN field of the server certificate.
+  You can set multiple IP addresses by repeating this option.
+  By default, it uses the IP address of the nodes.
+* --tls-cert-domain is the domain name of the server certificate.
+  Optional. This value is used in the additional SAN field of the server certificate.
+  You can set multiple domains by repeating this option.
+  This value is effective only when \`--tls-cert\` is not set.
 * --renew-ca is a flag to force renewing CA certificate & key.
   Optional. If set, CA certificate & key are also renewed (newly generated).
 * --no-tls is a flag to skip generating TLS certificates and remove existing certificates.


### PR DESCRIPTION
Switch dev-cluster to "rootless" mode.

After this change is merged, dev-cluster works as a single node cluster due to limitations of minikube ( https://github.com/kubernetes/minikube/issues/14146#issuecomment-1919751383 ).
All communications over network goes through `kubectl port-forward`.

## Related Issue

- closes #339 